### PR TITLE
[feat] 배송 관련 vo 추가

### DIFF
--- a/delivery-service/build.gradle
+++ b/delivery-service/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/Delivery.java
@@ -1,0 +1,77 @@
+package com.winner.client.deliveryservice.delivery.domain.entity;
+
+import com.winner.client.deliveryservice.delivery.domain.enums.DeliveryStatus;
+import com.winner.client.deliveryservice.delivery.domain.vo.Address;
+import com.winner.client.deliveryservice.delivery.domain.vo.HubRoute;
+import com.winner.client.deliveryservice.delivery.domain.vo.Location;
+import com.winner.client.deliveryservice.delivery.domain.vo.Receiver;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity
+@Table(
+    name = "p_delivery",
+    uniqueConstraints = @UniqueConstraint(name = "uq_delivery_orders_id", columnNames = "orders_id")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Delivery {
+
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "orders_id", nullable = false, updatable = false)
+  private UUID ordersId;
+
+  @Embedded
+  private HubRoute hubRoute;
+
+  @Embedded
+  private Receiver receiver;
+
+  @Embedded
+  private Address address;
+
+  @Embedded
+  private Location location;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private DeliveryStatus status;
+
+  @Column(name = "delivery_manager_id")
+  private UUID deliveryManagerId;
+
+  private Delivery(
+      UUID ordersId, HubRoute hubRoute, Receiver receiver,
+      Address address, Location location, UUID deliveryManagerId) {
+    this.ordersId = ordersId;
+    this.hubRoute = hubRoute;
+    this.receiver = receiver;
+    this.address = address;
+    this.location = location;
+    this.status = DeliveryStatus.CREATED;
+    this.deliveryManagerId = deliveryManagerId;
+  }
+
+  public static Delivery create(
+      UUID ordersId, HubRoute hubRoute, Receiver receiver,
+      Address address, Location location, UUID deliveryManagerId) {
+    return new Delivery(ordersId, hubRoute, receiver, address, location, deliveryManagerId);
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/DeliveryRoute.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/DeliveryRoute.java
@@ -1,0 +1,90 @@
+package com.winner.client.deliveryservice.delivery.domain.entity;
+
+import com.winner.client.deliveryservice.delivery.domain.enums.DeliveryRouteStatus;
+import com.winner.client.deliveryservice.delivery.domain.vo.CurrentHubRoute;
+import com.winner.client.deliveryservice.delivery.domain.vo.Distance;
+import com.winner.client.deliveryservice.delivery.domain.vo.Duration;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity
+@Table(
+    name = "p_delivery_route_steps",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uq_route_steps_delivery_seq",
+        columnNames = {"delivery_id", "seq"}
+    )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryRoute {
+
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "delivery_id", nullable = false, updatable = false)
+  private UUID deliveryId;
+
+  @Column(name = "seq", nullable = false)
+  private int seq;
+
+  @Embedded
+  private CurrentHubRoute currentHubRoute;
+
+  @Column(name = "estimated_distance", nullable = false, precision = 10, scale = 2)
+  private Distance estimatedDistance;
+
+  @Column(name = "estimated_arrival_time", nullable = false)
+  private Duration estimatedArrivalTime;
+
+  @Column(name = "actual_distance", precision = 10, scale = 2)
+  private Distance actualDistance;
+
+  @Column(name = "actual_arrival_time")
+  private Duration actualArrivalTime;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false)
+  private DeliveryRouteStatus status;
+
+  @Column(name = "delivery_manager_id", nullable = false)
+  private UUID deliveryManagerId;
+
+  private static void validateSeq(int seq) {
+    if (seq < 0) {
+      throw new IllegalArgumentException("순번은 0 이상이어야 합니다.");
+    }
+  }
+
+  public DeliveryRoute(UUID deliveryId, int seq, CurrentHubRoute currentHubRoute,
+      Distance estimatedDistance, Duration estimatedArrivalTime, UUID deliveryManagerId) {
+    this.deliveryId = deliveryId;
+    this.seq = seq;
+    this.currentHubRoute = currentHubRoute;
+    this.estimatedDistance = estimatedDistance;
+    this.estimatedArrivalTime = estimatedArrivalTime;
+    this.status = DeliveryRouteStatus.WAITING;
+    this.deliveryManagerId = deliveryManagerId;
+  }
+
+  public static DeliveryRoute create(UUID deliveryId, int seq, CurrentHubRoute currentHubRoute,
+      Distance estimatedDistance, Duration estimatedArrivalTime, UUID deliveryManagerId){
+    validateSeq(seq);
+    return new DeliveryRoute(deliveryId, seq, currentHubRoute, estimatedDistance, estimatedArrivalTime, deliveryManagerId);
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/enums/DeliveryRouteStatus.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/enums/DeliveryRouteStatus.java
@@ -1,0 +1,9 @@
+package com.winner.client.deliveryservice.delivery.domain.enums;
+
+public enum DeliveryRouteStatus {
+  WAITING,
+  ASSIGNED,
+  IN_PROGRESS,
+  COMPLETED,
+  CANCELLED
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/enums/DeliveryStatus.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/enums/DeliveryStatus.java
@@ -1,0 +1,12 @@
+package com.winner.client.deliveryservice.delivery.domain.enums;
+
+public enum DeliveryStatus {
+  CREATED,
+  HUB_WAITING,
+  HUB_MOVING,
+  DESTINATION_ARRIVED,
+  FOR_VENDOR_MOVING,
+  COMPLETED,
+  CANCELLED,
+  CANCEL_REQUESTED
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/Address.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/Address.java
@@ -1,0 +1,29 @@
+package com.winner.client.deliveryservice.delivery.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Address {
+  private String roadAddress;
+  private String detailAddress;
+
+  public Address(String roadAddress, String detailAddress) {
+    validateNotEmpty(roadAddress, "도로명 주소");
+    validateNotEmpty(detailAddress, "상세 주소");
+    this.roadAddress = roadAddress;
+    this.detailAddress = detailAddress;
+  }
+
+  private void validateNotEmpty(String value, String fieldName) {
+    if (value == null || value.trim().isEmpty()) {
+      throw new IllegalArgumentException(fieldName + "는 비워둘 수 없습니다.");
+    }
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/CurrentHubRoute.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/CurrentHubRoute.java
@@ -1,0 +1,33 @@
+package com.winner.client.deliveryservice.delivery.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CurrentHubRoute {
+  @Column(name = "cur_hub_id", nullable = false)
+  private UUID curHubId;
+
+  @Column(name = "next_hub_id", nullable = false)
+  private UUID nextHubId;
+
+  public CurrentHubRoute(UUID curHubId, UUID nextHubId) {
+    validateDifferentHubs(curHubId, nextHubId);
+    this.curHubId = curHubId;
+    this.nextHubId = nextHubId;
+  }
+
+  private static void validateDifferentHubs(UUID curHubId, UUID nextHubId) {
+    if (curHubId.equals(nextHubId)) {
+      throw new IllegalArgumentException("현재 허브와 다음 허브는 동일할 수 없습니다.");
+    }
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/Distance.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/Distance.java
@@ -1,0 +1,22 @@
+package com.winner.client.deliveryservice.delivery.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Distance {
+  private int kilometers;
+
+  public Distance(int kilometers) {
+    if (kilometers <= 0) {
+      throw new IllegalArgumentException("거리는 0보다 커야 합니다.");
+    }
+    this.kilometers = kilometers;
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/Duration.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/Duration.java
@@ -1,0 +1,22 @@
+package com.winner.client.deliveryservice.delivery.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Duration {
+  private int minutes;
+
+  public Duration(int minutes) {
+    if (minutes <= 0) {
+      throw new IllegalArgumentException("소요 시간은 0보다 커야 합니다.");
+    }
+    this.minutes = minutes;
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/HubRoute.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/HubRoute.java
@@ -1,0 +1,33 @@
+package com.winner.client.deliveryservice.delivery.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HubRoute {
+  @Column(name = "origin_id", nullable = false)
+  private UUID originId;
+
+  @Column(name = "destination_id", nullable = false)
+  private UUID destinationId;
+
+  public HubRoute(UUID originId, UUID destinationId) {
+    validateDifferentHubs(originId, destinationId);
+    this.originId = originId;
+    this.destinationId = destinationId;
+  }
+
+  private static void validateDifferentHubs(UUID originId, UUID destinationId) {
+    if (originId.equals(destinationId)) {
+      throw new IllegalArgumentException("출발 허브와 도착 허브는 동일할 수 없습니다.");
+    }
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/Location.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/Location.java
@@ -1,0 +1,35 @@
+package com.winner.client.deliveryservice.delivery.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Location {
+  private double latitude;
+  private double longitude;
+
+  public Location(double latitude, double longitude) {
+    validateLatitude(latitude);
+    validateLongitude(longitude);
+    this.latitude = latitude;
+    this.longitude = longitude;
+  }
+
+  private void validateLatitude(double latitude) {
+    if (latitude < -90 || latitude > 90) {
+      throw new IllegalArgumentException("위도(latitude)는 -90 ~ 90 범위여야 합니다.");
+    }
+  }
+
+  private void validateLongitude(double longitude) {
+    if (longitude < -180 || longitude > 180) {
+      throw new IllegalArgumentException("경도(longitude)는 -180 ~ 180 범위여야 합니다.");
+    }
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/Receiver.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/Receiver.java
@@ -1,0 +1,25 @@
+package com.winner.client.deliveryservice.delivery.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Receiver {
+  @Column(name = "receiver", nullable = false, length = 20)
+  private String receiver;
+
+  @Column(name = "slack_id", nullable = false, length = 50)
+  private String slackId;
+
+  public Receiver(String receiver, String slackId) {
+    this.receiver = receiver;
+    this.slackId = slackId;
+  }
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #16 

### 📌 작업 내용
- 배송 및 배송경로 엔티티 생성
- 배송/배송경로 상태 관리를 위한 Enum 추가
- 도메인 특성에 맞게 Value Object(VO) 분리

### ✨ 변경 사항
- 배송 관련 도메인 신규 추가
- VO 도입으로 값 검증 및 불변성 보장

### 📝 리뷰 포인트 (선택)
- 배송 및 배송경로 엔티티에 따라 적절하게 VO를 분리하였는지
- 도메인 패키지 구조가 적절한지
- VO 클래스명이 직관적으로 작성되었는지

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)