### PR TITLE
[fix] global 모듈 errorcode 및 배달 경로 엔티티 수정

### DIFF
--- a/company-service/src/main/resources/application-test.yaml
+++ b/company-service/src/main/resources/application-test.yaml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: postgres12
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: public
+    show-sql: true
+  sql:
+    init:
+      mode: never

--- a/company-service/src/main/resources/application.yaml
+++ b/company-service/src/main/resources/application.yaml
@@ -1,3 +1,22 @@
 spring:
   application:
     name: company-service
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:logistics}
+    username: ${POSTGRES_USER:postgres}
+    password: ${POSTGRES_PASSWORD:logistics1234}
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: false
+    show-sql: false
+    open-in-view: false
+    properties:
+      hibernate:
+        default_schema: ${POSTGRES_DEFAULT_SCHEMA:logistics}
+        format_sql: false
+        jdbc.time_zone: Asia/Seoul
+  sql:
+    init:
+      mode: never

--- a/company-service/src/main/resources/application.yaml
+++ b/company-service/src/main/resources/application.yaml
@@ -3,20 +3,21 @@ spring:
     name: company-service
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_PORT:5432}/${POSTGRES_DB:logistics}
-    username: ${POSTGRES_USER:postgres}
-    password: ${POSTGRES_PASSWORD:logistics1234}
+    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: create-drop
-    defer-datasource-initialization: false
+    defer-datasource-initialization: true
     show-sql: false
     open-in-view: false
     properties:
       hibernate:
-        default_schema: ${POSTGRES_DEFAULT_SCHEMA:logistics}
-        format_sql: false
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: ${POSTGRES_DEFAULT_SCHEMA}
+        format_sql: true
         jdbc.time_zone: Asia/Seoul
   sql:
     init:
-      mode: never
+      mode: always

--- a/company-service/src/test/java/com/winner/client/companyservice/CompanyServiceApplicationTests.java
+++ b/company-service/src/test/java/com/winner/client/companyservice/CompanyServiceApplicationTests.java
@@ -2,8 +2,10 @@ package com.winner.client.companyservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CompanyServiceApplicationTests {
 
 	@Test

--- a/delivery-service/build.gradle
+++ b/delivery-service/build.gradle
@@ -30,6 +30,7 @@ ext {
 }
 
 dependencies {
+    implementation project(':global')
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/DeliveryRoute.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/DeliveryRoute.java
@@ -4,6 +4,7 @@ import com.winner.client.deliveryservice.delivery.domain.enums.DeliveryRouteStat
 import com.winner.client.deliveryservice.delivery.domain.vo.CurrentHubRoute;
 import com.winner.client.deliveryservice.delivery.domain.vo.Distance;
 import com.winner.client.deliveryservice.delivery.domain.vo.Duration;
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -46,16 +47,20 @@ public class DeliveryRoute {
   @Embedded
   private CurrentHubRoute currentHubRoute;
 
-  @Column(name = "estimated_distance", nullable = false, precision = 10, scale = 2)
+  @Embedded
+  @AttributeOverride(name = "kilometers", column = @Column(name = "estimated_distance", nullable = false))
   private Distance estimatedDistance;
 
-  @Column(name = "estimated_arrival_time", nullable = false)
+  @Embedded
+  @AttributeOverride(name = "minutes", column = @Column(name = "estimated_arrival_time", nullable = false))
   private Duration estimatedArrivalTime;
 
-  @Column(name = "actual_distance", precision = 10, scale = 2)
+  @Embedded
+  @AttributeOverride(name = "kilometers", column = @Column(name = "actual_distance"))
   private Distance actualDistance;
 
-  @Column(name = "actual_arrival_time")
+  @Embedded
+  @AttributeOverride(name = "minutes", column = @Column(name = "actual_arrival_time"))
   private Duration actualArrivalTime;
 
   @Enumerated(EnumType.STRING)

--- a/delivery-service/src/main/resources/application-test.yaml
+++ b/delivery-service/src/main/resources/application-test.yaml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: postgres12
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: public
+    show-sql: true
+  sql:
+    init:
+      mode: never

--- a/delivery-service/src/main/resources/application.yaml
+++ b/delivery-service/src/main/resources/application.yaml
@@ -3,20 +3,34 @@ spring:
     name: delivery-service
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
-    username: postgres
-    password: postgres12
     driver-class-name: org.postgresql.Driver
-
+    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
+    defer-datasource-initialization: true
+    show-sql: false
+    open-in-view: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
-        default_schema: delivery_db
-    show-sql: true
-
+        default_schema: ${POSTGRES_DEFAULT_SCHEMA}
+        format_sql: true
+        jdbc.time_zone: Asia/Seoul
   sql:
     init:
       mode: always
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:17001/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    hostname: localhost
+    prefer-ip-address: true
+    lease-renewal-interval-in-seconds: 30
+    lease-expiration-duration-in-seconds: 90

--- a/delivery-service/src/main/resources/application.yaml
+++ b/delivery-service/src/main/resources/application.yaml
@@ -1,3 +1,22 @@
 spring:
   application:
     name: delivery-service
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: postgres12
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: delivery_db
+    show-sql: true
+
+  sql:
+    init:
+      mode: always

--- a/delivery-service/src/test/java/com/winner/client/deliveryservice/DeliveryServiceApplicationTests.java
+++ b/delivery-service/src/test/java/com/winner/client/deliveryservice/DeliveryServiceApplicationTests.java
@@ -2,8 +2,10 @@ package com.winner.client.deliveryservice;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class DeliveryServiceApplicationTests {
 
 	@Test

--- a/global/src/main/java/com/winner/client/global/code/BaseCode.java
+++ b/global/src/main/java/com/winner/client/global/code/BaseCode.java
@@ -1,4 +1,4 @@
-package com.winner.client.global.response;
+package com.winner.client.global.code;
 
 import org.springframework.http.HttpStatus;
 

--- a/global/src/main/java/com/winner/client/global/code/ErrorCode.java
+++ b/global/src/main/java/com/winner/client/global/code/ErrorCode.java
@@ -1,0 +1,3 @@
+package com.winner.client.global.code;
+
+public interface ErrorCode extends BaseCode { }

--- a/global/src/main/java/com/winner/client/global/exception/BusinessException.java
+++ b/global/src/main/java/com/winner/client/global/exception/BusinessException.java
@@ -1,5 +1,6 @@
 package com.winner.client.global.exception;
 
+import com.winner.client.global.code.ErrorCode;
 import lombok.Getter;
 
 @Getter

--- a/global/src/main/java/com/winner/client/global/exception/CommonErrorCode.java
+++ b/global/src/main/java/com/winner/client/global/exception/CommonErrorCode.java
@@ -1,13 +1,13 @@
 package com.winner.client.global.exception;
 
-import com.winner.client.global.response.BaseCode;
+import com.winner.client.global.code.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ErrorCode implements BaseCode {
+public enum CommonErrorCode implements ErrorCode {
   INVALID_INPUT("ERROR_001", HttpStatus.BAD_REQUEST, "잘못된 입력입니다."),
   UNAUTHORIZED("ERROR_002", HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
   FORBIDDEN("ERROR_003", HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/global/src/main/java/com/winner/client/global/response/ApiResponse.java
+++ b/global/src/main/java/com/winner/client/global/response/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.winner.client.global.response;
 
-import com.winner.client.global.exception.ErrorCode;
+import com.winner.client.global.code.BaseCode;
+import com.winner.client.global.code.ErrorCode;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
@@ -25,7 +26,7 @@ public class ApiResponse<T> {
     this.timestamp = LocalDateTime.now();
   }
 
-  public static <T> ApiResponse<T> success(SuccessCode  successCode, T data) {
+  public static <T> ApiResponse<T> success(CommonSuccessCode successCode, T data) {
     return new ApiResponse<>(successCode, data);
   }
 

--- a/global/src/main/java/com/winner/client/global/response/CommonSuccessCode.java
+++ b/global/src/main/java/com/winner/client/global/response/CommonSuccessCode.java
@@ -1,12 +1,13 @@
 package com.winner.client.global.response;
 
+import com.winner.client.global.code.BaseCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum SuccessCode implements BaseCode {
+public enum CommonSuccessCode implements BaseCode {
   OK(HttpStatus.OK, "COMMON_S001", "성공하였습니다."),
   CREATED(HttpStatus.CREATED, "COMMON_S002", "생성되었습니다."),
   DELETED(HttpStatus.OK, "COMMON_S003", "삭제되었습니다.");


### PR DESCRIPTION
### 📎 관련 이슈
- close #39 

### 📌 작업 내용
- ErrorCode 인터페이스를 추가하여 외부 서비스에서도 공통적으로 사용할 수 있도록 구조 개선
- 배달 경로 엔티티에서 @Embedded와 @Column 사용 충돌로 인해 발생하던 빌드 오류 수정

### ✨ 변경 사항
- ErrorCode를 인터페이스로 분리하여 공통 모듈에서 재사용 가능하도록 변경
- @Embedded 객체 필드와 @Column 중복 매핑 문제를 제거하고 JPA 매핑 구조 정리

### 📝 리뷰 포인트
- ErrorCode를 인터페이스로 분리한 구조가 공통 모듈로서 적절한지
- @Embedded 사용 방식 및 엔티티 매핑 구조가 올바르게 개선되었는지

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)
<img width="400" height="120" alt="image" src="https://github.com/user-attachments/assets/046e3bdf-95a5-45f1-bd31-1bfb82c58970" />
