### PR TITLE
[feat]: Add DeliveryManagerCompany entity and related value objects

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
@@ -1,0 +1,79 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.domain.entity;
+
+import com.winner.client.deliveryservice.common.constants.DeliveryManagerStatus;
+import com.winner.client.deliveryservice.deliverymanagercompany.domain.vo.AssignmentOrder;
+import com.winner.client.deliveryservice.deliverymanagercompany.domain.vo.DeliveryManagerUserId;
+import com.winner.client.deliveryservice.deliverymanagercompany.domain.vo.HubId;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity
+@Table(name = "p_delivery_manager_company", schema = "delivery")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class DeliveryManagerCompany {
+
+	@Getter
+	@Id
+	@GeneratedValue
+	@UuidGenerator
+	@Column(name = "id", nullable = false)
+	private UUID id;
+
+	@Embedded
+	private DeliveryManagerUserId userId;
+
+	@Embedded
+	private HubId hubId;
+
+	@Embedded
+	private AssignmentOrder assignmentOrder;
+
+	@Getter
+	@Enumerated(EnumType.STRING)
+	@Column(name = "delivery_manager_status", nullable = false)
+	private DeliveryManagerStatus deliveryManagerStatus;
+
+	@Getter
+	@Column(name = "last_delivery_completed_time")
+	private LocalDateTime lastDeliveryCompletedTime;
+
+	public static DeliveryManagerCompany create(UUID userId, UUID hubId, Long assignmentOrder) {
+		DeliveryManagerCompany manager = new DeliveryManagerCompany();
+		manager.userId = new DeliveryManagerUserId(userId);
+		manager.hubId = new HubId(hubId);
+		manager.assignmentOrder = new AssignmentOrder(assignmentOrder);
+		manager.deliveryManagerStatus = DeliveryManagerStatus.AVAILABLE;
+		return manager;
+	}
+
+	public void assignDelivery(UUID deliveryId) {
+		if (!this.deliveryManagerStatus.isAvailable()) {
+			throw new IllegalStateException("배송 가능 상태가 아닙니다.");
+		}
+		this.deliveryManagerStatus = DeliveryManagerStatus.IN_DELIVERY;
+	}
+
+	public void completeDelivery() {
+		this.lastDeliveryCompletedTime = LocalDateTime.now();
+		this.deliveryManagerStatus = DeliveryManagerStatus.AVAILABLE;
+	}
+
+	public void changeHub(UUID newHubId) {
+		this.hubId = new HubId(newHubId);
+	}
+
+	public UUID getUserId() { return userId.getValue(); }
+	public UUID getHubId() { return hubId.getValue(); }
+	public Long getAssignmentOrder() { return assignmentOrder.getValue(); }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
 @Entity
-@Table(name = "p_delivery_manager_company", schema = "delivery")
+@Table(name = "p_delivery_manager_company")
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class DeliveryManagerCompany {
 

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/AssignmentOrder.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/AssignmentOrder.java
@@ -1,0 +1,23 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class AssignmentOrder {
+
+	@Column(name = "assignment_order", nullable = false)
+	private Long value;
+
+	public AssignmentOrder(Long value) {
+		if (value == null || value < 0) {
+			throw new IllegalArgumentException("value must be greater than or equal to 0");
+		}
+		this.value = value;
+	}
+
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/DeliveryManagerUserId.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/DeliveryManagerUserId.java
@@ -1,0 +1,23 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class DeliveryManagerUserId {
+
+	@Column(name = "delivery_manager_id", nullable = false)
+	private UUID value;
+
+	public DeliveryManagerUserId(UUID value) {
+		if (value == null) {
+			throw new IllegalArgumentException("value cannot be null");
+		}
+		this.value = value;
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/HubId.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/HubId.java
@@ -1,0 +1,20 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class HubId {
+
+	@Column(name = "hub_id", nullable = false)
+	private UUID value;
+
+	public HubId(UUID value) {
+		this.value = value;
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/domain/vo/DeliveryManagerUserId.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/domain/vo/DeliveryManagerUserId.java
@@ -1,5 +1,6 @@
 package com.winner.client.deliveryservice.deliverymanagerhub.domain.vo;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.UUID;
 import lombok.Getter;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class DeliveryManagerUserId {
+
+	@Column(name = "delivery_manager_id", nullable = false)
 	private UUID value;
 
 	public DeliveryManagerUserId(UUID value) {


### PR DESCRIPTION
### 📎 관련 이슈
- #25 

### 📌 작업 내용
- 업체배송담당자 엔티티 생성 및 vo 구분

### ✨ 변경 사항
- 업체배송담당자 엔티티 생성
- vo 구분

### 📝 리뷰 포인트 (선택)
- 현재는 업체 배송담당자 <-> 허브 배송담당자 두 엔티티의 차이가 허브아이디의 존재 여부만 차이가 있어 모호하지만,
사실상 다른 역할을 하는 애그리거트라고 생각해서 공통 vo를 따로 두지 않고 중복으로 작성했습니다.
후에 요구사항 변경 등으로 인해 분리할 경우를 생각했을 때 이것이 더 유연한 구조라고 판단했습니다. 

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)