### PR TITLE
[feat] 허브 및 허브 간 경로 도메인과 DB 설정 추가

### DIFF
--- a/hub-service/src/main/resources/application.yaml
+++ b/hub-service/src/main/resources/application.yaml
@@ -1,3 +1,36 @@
 spring:
   application:
     name: hub-service
+
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    defer-datasource-initialization: true
+    show-sql: false
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: ${POSTGRES_DEFAULT_SCHEMA}
+        format_sql: true
+        jdbc.time_zone: Asia/Seoul
+  sql:
+    init:
+      mode: always
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:17001/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    hostname: localhost
+    prefer-ip-address: true
+    lease-renewal-interval-in-seconds: 30
+    lease-expiration-duration-in-seconds: 90


### PR DESCRIPTION
### 📎 관련 이슈
- close #45 

### 📌 작업 내용
- Hub, HubRoute 엔티티 설계 및 구현
- Value Object (VO) 적용 (HubId 등)
- PostgreSQL 연동 및 schema 설정
- application.yaml에 DB 설정 추가

### ✨ 변경 사항
- hub, hub_route 테이블 생성
- JPA 기반 DB 자동 생성 설정 적용
- default_schema를 hub_db로 설정

### 📝 리뷰 포인트
- 없음

### 🧠 기타 참고 사항
- DB 초기화(init.sql)는 팀 정책 미정으로 제외