### PR TITLE
[Feat] 라우팅 및 DB 설정 추가

### DIFF
--- a/gateway/src/main/resources/application-router.yaml
+++ b/gateway/src/main/resources/application-router.yaml
@@ -1,0 +1,50 @@
+spring:
+  cloud:
+    gateway:
+      server:
+        webflux:
+          routes:
+            - id: user-service
+              uri: lb://USER-SERVICE
+              predicates:
+                - Path=/api/v1/users/**, /api/v1/auth/**, /api/v1/admin/users/**
+
+            - id: order-service
+              uri: lb://ORDER-SERVICE
+              predicates:
+                - Path=/api/v1/orders/**
+
+            - id: product-service
+              uri: lb://PRODUCT-SERVICE
+              predicates:
+                - Path=/api/v1/products/**
+
+            - id: company-service
+              uri: lb://COMPANY-SERVICE
+              predicates:
+                - Path=/api/v1/companies/**
+
+            - id: shipping-service
+              uri: lb://SHIPPING-SERVICE
+              predicates:
+                - Path=/api/v1/deliveries/**
+
+            - id: driver-service
+              uri: lb://DRIVER-SERVICE
+              predicates:
+                - Path=/api/v1/delivery-managers/**
+
+            - id: hub-service
+              uri: lb://HUB-SERVICE
+              predicates:
+                - Path=/api/v1/hubs/**
+
+            - id: hub-path-service
+              uri: lb://HUB-PATH-SERVICE
+              predicates:
+                - Path=/api/v1/hub-routes/**
+
+            - id: slack-service
+              uri: lb://SLACK-SERVICE
+              predicates:
+                - Path=/api/v1/notifications/**, /api/v1/slacks/**

--- a/gateway/src/main/resources/application.yaml
+++ b/gateway/src/main/resources/application.yaml
@@ -1,5 +1,31 @@
 spring:
   application:
     name: gateway
+  profiles:
+    include:
+      - router
   main:
     web-application-type: reactive
+
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST}
+      port: 6379
+      password: ${SPRING_DATA_REDIS_PASSWORD}
+      database: 0
+      timeout: 2000ms
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 0
+          
+server:
+  port: 17002
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:17001/eureka/
+    register-with-eureka: true
+    fetch-registry: true


### PR DESCRIPTION
### 📎 관련 이슈
- close #44

### 📌 작업 내용
- **게이트웨이 라우팅 설정**: 9개 마이크로서비스의 라우팅 정보를 `application-router.yaml`로 등록
- **인프라 기본 설정**: Eureka 서비스 디스커버리 연동 및 Redis 설정(환경 변수 기반)을 완료했습니다.

### ✨ 변경 사항
#### 1. 라우팅 (`gateway/src/main/resources/application-router.yaml`)
- **동적 라우팅 적용**: `lb://` 프로토콜을 사용하여 Eureka에 등록된 서비스 이름으로 자동 로드밸런싱되도록 설정했습니다.
- **도메인별 경로 매칭**

### 📝 리뷰 포인트
- **서비스 ID**:  각 도메인에서는 자신의 `spring.application.name`이 `application-router.yaml`에 정의된 서비스 ID(예: `ORDER-SERVICE`)와 일치하는지 확인
- 경로 누락 여부 체크해주세요

### 🧠 기타 참고 사항