### PR TITLE
[Feat] Jwt 로직 구현

### DIFF
--- a/global/build.gradle
+++ b/global/build.gradle
@@ -1,31 +1,79 @@
 plugins {
-	id 'java-library'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java-library'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'sparta.project.logistics.global'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
+}
+
+configurations {
+    jwtLib {
+        canBeResolved = true
+        canBeConsumed = true
+    }
+    api.extendsFrom(jwtLib)
+    implementation.extendsFrom(jwtLib)
+    testImplementation.extendsFrom(jwtLib)
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.12"
-	}
+    imports {
+        mavenBom "org.springframework.boot:spring-boot-dependencies:3.5.12"
+    }
 }
 
 dependencies {
-	implementation 'org.springframework:spring-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework:spring-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    jwtLib 'io.jsonwebtoken:jjwt-api:0.11.5'
+    jwtLib 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    jwtLib 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+artifacts {
+    jwtLib jar
+}
+
+tasks.withType(Test).configureEach {
+    systemProperty "file.encoding", "UTF-8"
+}
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+
+    def envFile = rootProject.file('.env')
+    if (envFile.exists()) {
+        envFile.eachLine { line ->
+            if (line.trim() && !line.startsWith('#')) {
+                def (key, value) = line.tokenize('=')
+                environment key.trim(), value.trim()
+            }
+        }
+    }
+    testLogging {
+        events "passed", "skipped", "failed"
+        showStandardStreams = true
+        exceptionFormat = "full"
+    }
 }

--- a/global/src/main/java/com/winner/client/global/config/jwt/JwtConfig.java
+++ b/global/src/main/java/com/winner/client/global/config/jwt/JwtConfig.java
@@ -1,0 +1,10 @@
+package com.winner.client.global.config.jwt;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties
+public class JwtConfig {
+
+}

--- a/global/src/main/java/com/winner/client/global/config/jwt/JwtTokenProvider.java
+++ b/global/src/main/java/com/winner/client/global/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,94 @@
+package com.winner.client.global.config.jwt;
+
+import com.winner.client.global.exception.BusinessException;
+import com.winner.client.global.exception.JwtTokenErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+  @Value("${jwt.secret}")
+  private String secret;
+  @Value("${jwt.access_expiration_time}")
+  private Long accessExpirationTime;
+  @Value("${jwt.refresh_expiration_time}")
+  private Long refreshExpirationTime;
+  private SecretKey secretKey;
+
+  @PostConstruct
+  public void init() {
+    this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public String createAccessToken(UUID userId, String role, UUID referenceId) {
+    Date now = new Date();
+    Date expirationDate = new Date(now.getTime() + accessExpirationTime);
+
+    return Jwts.builder()
+        .setSubject(String.valueOf(userId))
+        .claim("role", role)
+        .claim("referenceId", referenceId)
+        .setIssuedAt(now)
+        .setExpiration(expirationDate)
+        .signWith(secretKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  public long getRemainingTime(String token) {
+    try {
+      Date expiration = getClaims(token).getExpiration();
+      long now = new Date().getTime();
+      return expiration.getTime() - now;
+    } catch (Exception e) {
+      return 0;
+    }
+  }
+
+  public String createRefreshToken(UUID userId) {
+    Date now = new Date();
+    Date expiryDate = new Date(now.getTime() + refreshExpirationTime);
+
+    return Jwts.builder()
+        .setSubject(String.valueOf(userId))
+        .setIssuedAt(now)
+        .setExpiration(expiryDate)
+        .signWith(secretKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  public Claims getClaims(String token) {
+    return Jwts.parserBuilder()
+        .setSigningKey(secretKey)
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+      return true;
+    } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+      throw new BusinessException(JwtTokenErrorCode.INVALID_SIGNATURE);
+    } catch (ExpiredJwtException e) {
+      throw new BusinessException(JwtTokenErrorCode.EXPIRED_TOKEN);
+    } catch (UnsupportedJwtException e) {
+      throw new BusinessException(JwtTokenErrorCode.UNSUPPORTED_TOKEN);
+    } catch (IllegalArgumentException e) {
+      throw new BusinessException(JwtTokenErrorCode.EMPTY_CLAIMS);
+    }
+  }
+}

--- a/global/src/main/java/com/winner/client/global/config/jwt/JwtTokenProvider.java
+++ b/global/src/main/java/com/winner/client/global/config/jwt/JwtTokenProvider.java
@@ -33,7 +33,7 @@ public class JwtTokenProvider {
     this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
   }
 
-  public String createAccessToken(UUID userId, String role, UUID referenceId) {
+  public String createAccessToken(UUID userId, String role, UUID referenceId,boolean userStatus) {
     Date now = new Date();
     Date expirationDate = new Date(now.getTime() + accessExpirationTime);
 
@@ -41,6 +41,7 @@ public class JwtTokenProvider {
         .setSubject(String.valueOf(userId))
         .claim("role", role)
         .claim("referenceId", referenceId)
+        .claim("status",userStatus)
         .setIssuedAt(now)
         .setExpiration(expirationDate)
         .signWith(secretKey, SignatureAlgorithm.HS256)

--- a/global/src/main/java/com/winner/client/global/exception/JwtTokenErrorCode.java
+++ b/global/src/main/java/com/winner/client/global/exception/JwtTokenErrorCode.java
@@ -1,0 +1,20 @@
+package com.winner.client.global.exception;
+
+import com.winner.client.global.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtTokenErrorCode implements ErrorCode {
+  INVALID_SIGNATURE("JWT_001", HttpStatus.UNAUTHORIZED, "잘못된 JWT 서명입니다."),
+  EXPIRED_TOKEN("JWT_002", HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+  UNSUPPORTED_TOKEN("JWT_003", HttpStatus.UNAUTHORIZED, "지원되지 않는 JWT 토큰입니다."),
+  EMPTY_CLAIMS("JWT_004", HttpStatus.BAD_REQUEST, "JWT 토큰이 비어있거나 잘못되었습니다."),
+  ;
+
+  private final String code;
+  private final HttpStatus status;
+  private final String message;
+}

--- a/global/src/main/resources/application.yaml
+++ b/global/src/main/resources/application.yaml
@@ -1,0 +1,4 @@
+jwt:
+  secret: ${JWT_SECRET}
+  access_expiration_time: 3600000
+  refresh_expiration_time: 604800000

--- a/global/src/test/java/com/winner/client/global/JwtTokenProviderTest.java
+++ b/global/src/test/java/com/winner/client/global/JwtTokenProviderTest.java
@@ -1,0 +1,89 @@
+package com.winner.client.global;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.winner.client.global.config.jwt.JwtTokenProvider;
+import com.winner.client.global.exception.BusinessException;
+import io.jsonwebtoken.Claims;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class JwtTokenProviderTest {
+
+  private JwtTokenProvider jwtTokenProvider;
+
+  private final Long TEST_ACCESS_TIME = 3600000L;
+  private final Long TEST_REFRESH_TIME = 604800000L;
+
+  @BeforeEach
+  void setUp() {
+    jwtTokenProvider = new JwtTokenProvider();
+
+    String envSecret = System.getenv("JWT_SECRET");
+
+    assertThat(envSecret)
+        .as("환경 변수 JWT_SECRET이 설정되지 않았습니다. .env 파일을 확인하세요.")
+        .isNotNull();
+    ReflectionTestUtils.setField(jwtTokenProvider, "secret", envSecret);
+    ReflectionTestUtils.setField(jwtTokenProvider, "accessExpirationTime", TEST_ACCESS_TIME);
+    ReflectionTestUtils.setField(jwtTokenProvider, "refreshExpirationTime", TEST_REFRESH_TIME);
+    jwtTokenProvider.init();
+  }
+
+  @Test
+  @DisplayName("AccessToken 생성 및 클레임 추출 성공 테스트")
+  void createAccessToken_Success() {
+    UUID userId = UUID.randomUUID();
+    String role = "ROLE_USER";
+    UUID referenceId = UUID.randomUUID();
+
+    String token = jwtTokenProvider.createAccessToken(userId, role, referenceId);
+    Claims claims = jwtTokenProvider.getClaims(token);
+
+    assertThat(token).isNotNull();
+    assertThat(claims.getSubject()).isEqualTo(userId.toString());
+    assertThat(claims.get("role")).isEqualTo(role);
+    assertThat(claims.get("referenceId")).isEqualTo(referenceId.toString());
+  }
+
+  @Test
+  @DisplayName("유효한 토큰 검증 성공")
+  void validateToken_Success() {
+    String token = jwtTokenProvider.createAccessToken(UUID.randomUUID(), "USER", UUID.randomUUID());
+    boolean isValid = jwtTokenProvider.validateToken(token);
+    assertThat(isValid).isTrue();
+  }
+
+  @Test
+  @DisplayName("만료된 토큰 검증 시 예외 발생")
+  void validateToken_Expired() {
+    ReflectionTestUtils.setField(jwtTokenProvider, "accessExpirationTime", 0L);
+    String expiredToken = jwtTokenProvider.createAccessToken(UUID.randomUUID(), "USER", UUID.randomUUID());
+
+    assertThatThrownBy(() -> jwtTokenProvider.validateToken(expiredToken))
+        .isInstanceOf(BusinessException.class);
+  }
+
+  @Test
+  @DisplayName("잘못된 형식의 토큰 검증 시 예외 발생")
+  void validateToken_Invalid() {
+    String invalidToken = "this.is.not.a.valid.jwt.token";
+    assertThatThrownBy(() -> jwtTokenProvider.validateToken(invalidToken))
+        .isInstanceOf(BusinessException.class);
+  }
+
+  @Test
+  @DisplayName("토큰의 남은 유효 시간 계산 성공")
+  void getRemainingTime_Success() {
+    String token = jwtTokenProvider.createAccessToken(UUID.randomUUID(), "USER", UUID.randomUUID());
+
+    long remainingTime = jwtTokenProvider.getRemainingTime(token);
+
+    assertThat(remainingTime).isGreaterThan(0);
+    assertThat(remainingTime).isLessThanOrEqualTo(TEST_ACCESS_TIME);
+  }
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #54

### 📌 작업 내용
- JWT 인증 핵심 로직(Provider) 구현
- 의존성 및 환경 설정
- 단위 테스트 완료

### ✨ 변경 사항
- `jwtLib` 으로 JWT 관련 의존성 전파 설정
- `JwtTokenProvider.java`: 
  - `HS256` 알고리즘 기반 Access/Refresh Token 생성 로직 추가
  - `UUID` 기반의 `userId`, `role`, `referenceId`를 클레임 관리
- `JwtTokenErrorCode.`: Jwt 관련 에러코드 정의
- `JwtTokenProviderTest`: 만료된 토큰 처리 및 클레임 일치 여부 등 테스트

### 📝 리뷰 포인트 (선택)
- 의존성 구성
- Claim에 필드가 적절한지
- 테스트를 더 해야 될 것이 있는지
- 많이 코드 지적해주세요..

### 🧠 기타 참고 사항
- 슬랙에 jwt 환경변수 업로드 하였으니 빌드나 CI 시 참고
- [의존성 전파에 관한 이야기](https://www.notion.so/teamsparta/3352dc3ef5148009ae44fba707ffd686?source=copy_link)