### PR TITLE
[feat]: 업체 배송 담당자 단건 조회 기능 개발

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/company/DeliveryManagerCompanyErrorCode.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/company/DeliveryManagerCompanyErrorCode.java
@@ -11,7 +11,9 @@ public enum DeliveryManagerCompanyErrorCode implements ErrorCode {
 	ALREADY_REGISTERED_COMPANY_DELIVERY_MANAGER("ERROR_601", HttpStatus.CONFLICT,
 		"이미 등록 된 업체 배송 담당자 입니다."),
 	EXCEEDED_TO_IN_HUB_DELIVERY_MANAGER("ERROR_602", HttpStatus.CONFLICT,
-		"허브 내에 배달담당자 TO 초과");
+		"허브 내에 배달담당자 TO 초과"),
+	NOT_FOUND_COMPANY_DELIVERY_MANAGER("ERROR_603", HttpStatus.NOT_FOUND,
+		"존재하지 않는 업체배송담당자 입니다.");
 
 	private final String code;
 	private final HttpStatus status;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyReadService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyReadService.java
@@ -8,9 +8,11 @@ import com.winner.client.global.exception.BusinessException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DeliveryManagerCompanyReadService {
 
 	private final DeliveryManagerCompanyRepository repository;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyReadService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyReadService.java
@@ -1,0 +1,23 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.application;
+
+import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.NOT_FOUND_COMPANY_DELIVERY_MANAGER;
+
+import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyInfoResult;
+import com.winner.client.deliveryservice.deliverymanagercompany.domain.repository.DeliveryManagerCompanyRepository;
+import com.winner.client.global.exception.BusinessException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryManagerCompanyReadService {
+
+	private final DeliveryManagerCompanyRepository repository;
+
+	public DeliveryManagerCompanyInfoResult getDetail(UUID id) {
+		return DeliveryManagerCompanyInfoResult.from(repository.findById(id).orElseThrow(
+			() -> new BusinessException(NOT_FOUND_COMPANY_DELIVERY_MANAGER)
+		));
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
@@ -3,7 +3,7 @@ package com.winner.client.deliveryservice.deliverymanagercompany.application;
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.ALREADY_REGISTERED_COMPANY_DELIVERY_MANAGER;
 
 import com.winner.client.deliveryservice.deliverymanagercompany.application.command.DeliveryManagerCompanyRegistrationCommand;
-import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyRegistrationResult;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyInfoResult;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.entity.DeliveryManagerCompany;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.repository.DeliveryManagerCompanyRepository;
 import com.winner.client.global.exception.BusinessException;
@@ -16,7 +16,7 @@ public class DeliveryManagerCompanyWriteService {
 
 	private final DeliveryManagerCompanyRepository repository;
 
-	public DeliveryManagerCompanyRegistrationResult registration(
+	public DeliveryManagerCompanyInfoResult registration(
 		DeliveryManagerCompanyRegistrationCommand command) {
 
 		if (repository.existByUserId(command.userId())) {
@@ -29,7 +29,7 @@ public class DeliveryManagerCompanyWriteService {
 				command.hubId()).map(last -> last.getAssignmentOrder() + 1)
 			.orElse(1L);
 
-		return DeliveryManagerCompanyRegistrationResult.from(
+		return DeliveryManagerCompanyInfoResult.from(
 			repository.save(
 				DeliveryManagerCompany.create(command.userId(), command.hubId(), nextAssignmentOrder, curCount)
 			));

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/result/DeliveryManagerCompanyInfoResult.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/result/DeliveryManagerCompanyInfoResult.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record DeliveryManagerCompanyRegistrationResult (
+public record DeliveryManagerCompanyInfoResult(
 	UUID userId,
 	UUID hubId,
 	String status,
@@ -14,10 +14,10 @@ public record DeliveryManagerCompanyRegistrationResult (
 	LocalDateTime lastDeliveryCompletedTime
 ) {
 
-	public static DeliveryManagerCompanyRegistrationResult from(
+	public static DeliveryManagerCompanyInfoResult from(
 		DeliveryManagerCompany entity) {
 
-		return DeliveryManagerCompanyRegistrationResult.builder()
+		return DeliveryManagerCompanyInfoResult.builder()
 			.userId(entity.getUserId())
 			.hubId(entity.getHubId())
 			.status(entity.getDeliveryManagerStatus().name())

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/repository/DeliveryManagerCompanyRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/repository/DeliveryManagerCompanyRepository.java
@@ -10,4 +10,5 @@ public interface DeliveryManagerCompanyRepository {
 	boolean existByUserId(UUID userId);
 	Optional<DeliveryManagerCompany> findLastAssignmentOrderByHubId(UUID hubId);
 	Long countByHubId(UUID hubId);
+	Optional<DeliveryManagerCompany> findById(UUID userId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/DeliveryManagerUserId.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/DeliveryManagerUserId.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class DeliveryManagerUserId {
 
-	@Column(name = "delivery_manager_id", nullable = false)
+	@Column(name = "user_id", nullable = false)
 	private UUID value;
 
 	public DeliveryManagerUserId(UUID value) {

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/DeliveryManagerCompanyJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/DeliveryManagerCompanyJpaRepository.java
@@ -34,4 +34,9 @@ public class DeliveryManagerCompanyJpaRepository implements
 	public Long countByHubId(UUID hubId) {
 		return jpaRepository.countByHubId_Value(hubId);
 	}
+
+	@Override
+	public Optional<DeliveryManagerCompany> findById(UUID id) {
+		return jpaRepository.findById(id);
+	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
@@ -1,0 +1,35 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.presentation.api;
+
+import static com.winner.client.global.response.CommonSuccessCode.OK;
+
+import com.winner.client.deliveryservice.deliverymanagercompany.application.DeliveryManagerCompanyReadService;
+import com.winner.client.deliveryservice.deliverymanagercompany.presentation.responses.DeliveryManagerCompanyInfo;
+import com.winner.client.global.response.ApiResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/delivery-managers/company")
+public class DeliveryManagerCompanyController {
+
+	private final DeliveryManagerCompanyReadService deliveryManagerCompanyReadService;
+
+	@GetMapping("/{id}")
+	public ResponseEntity<ApiResponse<DeliveryManagerCompanyInfo>> getDeliveryManagerCompany(
+		@PathVariable UUID id
+	) {
+		return ResponseEntity.ok()
+			.body(ApiResponse.success(
+				OK,
+				DeliveryManagerCompanyInfo.from(
+					deliveryManagerCompanyReadService.getDetail(id)))
+			);
+	}
+
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
@@ -24,12 +24,8 @@ public class DeliveryManagerCompanyController {
 	public ResponseEntity<ApiResponse<DeliveryManagerCompanyInfo>> getDeliveryManagerCompany(
 		@PathVariable UUID id
 	) {
-		return ResponseEntity.ok()
-			.body(ApiResponse.success(
-				OK,
-				DeliveryManagerCompanyInfo.from(
-					deliveryManagerCompanyReadService.getDetail(id)))
-			);
+		return ResponseEntity.ok().body(ApiResponse.success(OK,
+			DeliveryManagerCompanyInfo.from(deliveryManagerCompanyReadService.getDetail(id))));
 	}
 
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/responses/DeliveryManagerCompanyInfo.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/responses/DeliveryManagerCompanyInfo.java
@@ -1,6 +1,6 @@
 package com.winner.client.deliveryservice.deliverymanagercompany.presentation.responses;
 
-import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyRegistrationResult;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyInfoResult;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
@@ -14,7 +14,7 @@ public record DeliveryManagerCompanyInfo(
 	LocalDateTime lastDeliveryCompletedTime
 ) {
 
-	public static DeliveryManagerCompanyInfo from(DeliveryManagerCompanyRegistrationResult result) {
+	public static DeliveryManagerCompanyInfo from(DeliveryManagerCompanyInfoResult result) {
 		return DeliveryManagerCompanyInfo.builder()
 			.userId(result.userId())
 			.hubId(result.hubId())


### PR DESCRIPTION
### 📎 관련 이슈
- #25

### 📌 작업 내용
- DeliveryManagerCompany 엔티티의 userId 속성 수정 (delivery_manager_id -> user_id)
- 업체 배송 담당자(DeliveryManagerCompany) 단건 조회 기능 구현
- 레이어 간 데이터 전송을 위한 DTO(Result, Info) 정의 및 변환 로직 추가

### ✨ 변경 사항
- **엔티티 수정**: DeliveryManagerCompany 내 `@Column` 매핑 이름을 `delivery_manager_id`에서 `user_id`로 변경
- **조회 서비스 구현**: `DeliveryManagerCompanyReadService`를 신설하여 리포지토리로부터 데이터를 조회하고, 데이터 부재 시 `BusinessException`을 던지도록 구현
- **계층별 DTO 재사용**:
    - `DeliveryManagerCompanyRegistrationResult` -> `DeliveryManagerCompanyInfoResult` 으로 이름 변경
    - `DeliveryManagerCompanyInfo`
- **컨트롤러 엔드포인트 추가**: GET `/api/v1/delivery-managers/company/{id}` API 

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항