### PR TITLE
25 feat company delivery manager crud u

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/company/DeliveryManagerCompanyErrorCode.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/company/DeliveryManagerCompanyErrorCode.java
@@ -11,7 +11,9 @@ public enum DeliveryManagerCompanyErrorCode implements ErrorCode {
 	ALREADY_REGISTERED_COMPANY_DELIVERY_MANAGER("ERROR_601", HttpStatus.CONFLICT,
 		"이미 등록 된 업체 배송 담당자 입니다."),
 	EXCEEDED_TO_IN_HUB_DELIVERY_MANAGER("ERROR_602", HttpStatus.CONFLICT,
-		"허브 내에 배달담당자 TO 초과");
+		"허브 내에 배달담당자 TO 초과"),
+	NOT_FOUND_COMPANY_DELIVERY_MANAGER("ERROR_603", HttpStatus.NOT_FOUND,
+		"존재하지 않는 업체배송담당자 입니다.");
 
 	private final String code;
 	private final HttpStatus status;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyReadService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyReadService.java
@@ -8,9 +8,11 @@ import com.winner.client.global.exception.BusinessException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DeliveryManagerCompanyReadService {
 
 	private final DeliveryManagerCompanyRepository repository;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyReadService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyReadService.java
@@ -1,0 +1,23 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.application;
+
+import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.NOT_FOUND_COMPANY_DELIVERY_MANAGER;
+
+import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyInfoResult;
+import com.winner.client.deliveryservice.deliverymanagercompany.domain.repository.DeliveryManagerCompanyRepository;
+import com.winner.client.global.exception.BusinessException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryManagerCompanyReadService {
+
+	private final DeliveryManagerCompanyRepository repository;
+
+	public DeliveryManagerCompanyInfoResult getDetail(UUID id) {
+		return DeliveryManagerCompanyInfoResult.from(repository.findById(id).orElseThrow(
+			() -> new BusinessException(NOT_FOUND_COMPANY_DELIVERY_MANAGER)
+		));
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
@@ -3,7 +3,7 @@ package com.winner.client.deliveryservice.deliverymanagercompany.application;
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.ALREADY_REGISTERED_COMPANY_DELIVERY_MANAGER;
 
 import com.winner.client.deliveryservice.deliverymanagercompany.application.command.DeliveryManagerCompanyRegistrationCommand;
-import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyRegistrationResult;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyInfoResult;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.entity.DeliveryManagerCompany;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.repository.DeliveryManagerCompanyRepository;
 import com.winner.client.global.exception.BusinessException;
@@ -16,7 +16,7 @@ public class DeliveryManagerCompanyWriteService {
 
 	private final DeliveryManagerCompanyRepository repository;
 
-	public DeliveryManagerCompanyRegistrationResult registration(
+	public DeliveryManagerCompanyInfoResult registration(
 		DeliveryManagerCompanyRegistrationCommand command) {
 
 		if (repository.existByUserId(command.userId())) {
@@ -29,7 +29,7 @@ public class DeliveryManagerCompanyWriteService {
 				command.hubId()).map(last -> last.getAssignmentOrder() + 1)
 			.orElse(1L);
 
-		return DeliveryManagerCompanyRegistrationResult.from(
+		return DeliveryManagerCompanyInfoResult.from(
 			repository.save(
 				DeliveryManagerCompany.create(command.userId(), command.hubId(), nextAssignmentOrder, curCount)
 			));

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
@@ -1,17 +1,21 @@
 package com.winner.client.deliveryservice.deliverymanagercompany.application;
 
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.ALREADY_REGISTERED_COMPANY_DELIVERY_MANAGER;
+import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.NOT_FOUND_COMPANY_DELIVERY_MANAGER;
 
 import com.winner.client.deliveryservice.deliverymanagercompany.application.command.DeliveryManagerCompanyRegistrationCommand;
 import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyInfoResult;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.entity.DeliveryManagerCompany;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.repository.DeliveryManagerCompanyRepository;
 import com.winner.client.global.exception.BusinessException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class DeliveryManagerCompanyWriteService {
 
 	private final DeliveryManagerCompanyRepository repository;
@@ -33,5 +37,13 @@ public class DeliveryManagerCompanyWriteService {
 			repository.save(
 				DeliveryManagerCompany.create(command.userId(), command.hubId(), nextAssignmentOrder, curCount)
 			));
+	}
+
+	public DeliveryManagerCompanyInfoResult switchStatus(UUID id) {
+		DeliveryManagerCompany deliveryManagerCompany = repository.findById(id).orElseThrow(
+				() -> new BusinessException(NOT_FOUND_COMPANY_DELIVERY_MANAGER)
+			);
+		deliveryManagerCompany.switchStatus();
+		return DeliveryManagerCompanyInfoResult.from(deliveryManagerCompany);
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/result/DeliveryManagerCompanyInfoResult.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/result/DeliveryManagerCompanyInfoResult.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record DeliveryManagerCompanyRegistrationResult (
+public record DeliveryManagerCompanyInfoResult(
 	UUID userId,
 	UUID hubId,
 	String status,
@@ -14,10 +14,10 @@ public record DeliveryManagerCompanyRegistrationResult (
 	LocalDateTime lastDeliveryCompletedTime
 ) {
 
-	public static DeliveryManagerCompanyRegistrationResult from(
+	public static DeliveryManagerCompanyInfoResult from(
 		DeliveryManagerCompany entity) {
 
-		return DeliveryManagerCompanyRegistrationResult.builder()
+		return DeliveryManagerCompanyInfoResult.builder()
 			.userId(entity.getUserId())
 			.hubId(entity.getHubId())
 			.status(entity.getDeliveryManagerStatus().name())

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
@@ -80,6 +80,13 @@ public class DeliveryManagerCompany extends BaseAuditEntity {
 		this.hubId = new HubId(newHubId);
 	}
 
+	public void switchStatus() {
+		switch (this.deliveryManagerStatus) {
+			case AVAILABLE -> this.deliveryManagerStatus = DeliveryManagerStatus.OFF_DUTY;
+			case OFF_DUTY -> this.deliveryManagerStatus = DeliveryManagerStatus.AVAILABLE;
+		}
+	}
+
 	public UUID getUserId() { return userId.getValue(); }
 	public UUID getHubId() { return hubId.getValue(); }
 	public Long getAssignmentOrder() { return assignmentOrder.getValue(); }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/repository/DeliveryManagerCompanyRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/repository/DeliveryManagerCompanyRepository.java
@@ -10,4 +10,5 @@ public interface DeliveryManagerCompanyRepository {
 	boolean existByUserId(UUID userId);
 	Optional<DeliveryManagerCompany> findLastAssignmentOrderByHubId(UUID hubId);
 	Long countByHubId(UUID hubId);
+	Optional<DeliveryManagerCompany> findById(UUID userId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/DeliveryManagerUserId.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/DeliveryManagerUserId.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class DeliveryManagerUserId {
 
-	@Column(name = "delivery_manager_id", nullable = false)
+	@Column(name = "user_id", nullable = false)
 	private UUID value;
 
 	public DeliveryManagerUserId(UUID value) {

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/DeliveryManagerCompanyJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/DeliveryManagerCompanyJpaRepository.java
@@ -34,4 +34,9 @@ public class DeliveryManagerCompanyJpaRepository implements
 	public Long countByHubId(UUID hubId) {
 		return jpaRepository.countByHubId_Value(hubId);
 	}
+
+	@Override
+	public Optional<DeliveryManagerCompany> findById(UUID id) {
+		return jpaRepository.findById(id);
+	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
@@ -1,0 +1,35 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.presentation.api;
+
+import static com.winner.client.global.response.CommonSuccessCode.OK;
+
+import com.winner.client.deliveryservice.deliverymanagercompany.application.DeliveryManagerCompanyReadService;
+import com.winner.client.deliveryservice.deliverymanagercompany.presentation.responses.DeliveryManagerCompanyInfo;
+import com.winner.client.global.response.ApiResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/delivery-managers/company")
+public class DeliveryManagerCompanyController {
+
+	private final DeliveryManagerCompanyReadService deliveryManagerCompanyReadService;
+
+	@GetMapping("/{id}")
+	public ResponseEntity<ApiResponse<DeliveryManagerCompanyInfo>> getDeliveryManagerCompany(
+		@PathVariable UUID id
+	) {
+		return ResponseEntity.ok()
+			.body(ApiResponse.success(
+				OK,
+				DeliveryManagerCompanyInfo.from(
+					deliveryManagerCompanyReadService.getDetail(id)))
+			);
+	}
+
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
@@ -24,12 +24,8 @@ public class DeliveryManagerCompanyController {
 	public ResponseEntity<ApiResponse<DeliveryManagerCompanyInfo>> getDeliveryManagerCompany(
 		@PathVariable UUID id
 	) {
-		return ResponseEntity.ok()
-			.body(ApiResponse.success(
-				OK,
-				DeliveryManagerCompanyInfo.from(
-					deliveryManagerCompanyReadService.getDetail(id)))
-			);
+		return ResponseEntity.ok().body(ApiResponse.success(OK,
+			DeliveryManagerCompanyInfo.from(deliveryManagerCompanyReadService.getDetail(id))));
 	}
 
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
@@ -3,12 +3,14 @@ package com.winner.client.deliveryservice.deliverymanagercompany.presentation.ap
 import static com.winner.client.global.response.CommonSuccessCode.OK;
 
 import com.winner.client.deliveryservice.deliverymanagercompany.application.DeliveryManagerCompanyReadService;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.DeliveryManagerCompanyWriteService;
 import com.winner.client.deliveryservice.deliverymanagercompany.presentation.responses.DeliveryManagerCompanyInfo;
 import com.winner.client.global.response.ApiResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class DeliveryManagerCompanyController {
 
 	private final DeliveryManagerCompanyReadService deliveryManagerCompanyReadService;
+	private final DeliveryManagerCompanyWriteService deliveryManagerCompanyWriteService;
 
 	@GetMapping("/{id}")
 	public ResponseEntity<ApiResponse<DeliveryManagerCompanyInfo>> getDeliveryManagerCompany(
@@ -28,4 +31,11 @@ public class DeliveryManagerCompanyController {
 			DeliveryManagerCompanyInfo.from(deliveryManagerCompanyReadService.getDetail(id))));
 	}
 
+	@PatchMapping("/{id}")
+	public ResponseEntity<ApiResponse<DeliveryManagerCompanyInfo>> switchStatus(
+		@PathVariable UUID id
+	) {
+		return ResponseEntity.ok().body(ApiResponse.success(OK,
+			DeliveryManagerCompanyInfo.from(deliveryManagerCompanyWriteService.switchStatus(id))));
+	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/responses/DeliveryManagerCompanyInfo.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/responses/DeliveryManagerCompanyInfo.java
@@ -1,6 +1,6 @@
 package com.winner.client.deliveryservice.deliverymanagercompany.presentation.responses;
 
-import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyRegistrationResult;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyInfoResult;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
@@ -14,7 +14,7 @@ public record DeliveryManagerCompanyInfo(
 	LocalDateTime lastDeliveryCompletedTime
 ) {
 
-	public static DeliveryManagerCompanyInfo from(DeliveryManagerCompanyRegistrationResult result) {
+	public static DeliveryManagerCompanyInfo from(DeliveryManagerCompanyInfoResult result) {
 		return DeliveryManagerCompanyInfo.builder()
 			.userId(result.userId())
 			.hubId(result.hubId())


### PR DESCRIPTION
### 📎 관련 이슈
- #25

### 📌 작업 내용
- 배송 담당자(DeliveryManagerCompany)의 업무 상태(출근/휴무 등)를 전환하는 토글 기능 구현
- 상태 변경을 위한 컨트롤러 엔드포인트 및 서비스 레이어 로직 추가

### ✨ 변경 사항
- **상태 변경 메서드**: `DeliveryManagerCompany` 엔티티 내에서 상태 전이를 담당하는 `switchStatus` 로직 구현
- **서비스 레이어**: `DeliveryManagerCompanyWriteService`에 `@Transactional` 추가
- **컨트롤러 엔드포인트**: `PATCH /api/v1/delivery-managers/company/{id}` 경로를 통해 상태 변경 요청을 처리하는 API 추가

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항
- 배송담당자 수정 기능이 뭐가 필요할지 고민해봤지만 요청으로 수정할 데이터가 없어서 억지로 만든 api 입니다.