### PR TITLE
[feat]: 업체 배송담당자 업데이트 및 삭제 기능 구현

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/company/DeliveryManagerCompanyErrorCode.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/company/DeliveryManagerCompanyErrorCode.java
@@ -13,7 +13,9 @@ public enum DeliveryManagerCompanyErrorCode implements ErrorCode {
 	EXCEEDED_TO_IN_HUB_DELIVERY_MANAGER("ERROR_602", HttpStatus.CONFLICT,
 		"허브 내에 배달담당자 TO 초과"),
 	NOT_FOUND_COMPANY_DELIVERY_MANAGER("ERROR_603", HttpStatus.NOT_FOUND,
-		"존재하지 않는 업체배송담당자 입니다.");
+		"존재하지 않는 업체배송담당자 입니다."),
+	DELIVERY_MANAGER_IN_PROGRESS("ERROR_604", HttpStatus.BAD_REQUEST,
+		"업무 진행 중엔 탈퇴가 불가능 합니다.");
 
 	private final String code;
 	private final HttpStatus status;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
@@ -46,4 +46,10 @@ public class DeliveryManagerCompanyWriteService {
 		deliveryManagerCompany.switchStatus();
 		return DeliveryManagerCompanyInfoResult.from(deliveryManagerCompany);
 	}
+
+	public void deactivate(UUID userId) {
+		DeliveryManagerCompany deliveryManagerCompany = repository.findByUserId(userId)
+			.orElseThrow(() -> new BusinessException(NOT_FOUND_COMPANY_DELIVERY_MANAGER));
+		deliveryManagerCompany.softDelete(userId);
+	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
@@ -1,17 +1,21 @@
 package com.winner.client.deliveryservice.deliverymanagercompany.application;
 
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.ALREADY_REGISTERED_COMPANY_DELIVERY_MANAGER;
+import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.NOT_FOUND_COMPANY_DELIVERY_MANAGER;
 
 import com.winner.client.deliveryservice.deliverymanagercompany.application.command.DeliveryManagerCompanyRegistrationCommand;
 import com.winner.client.deliveryservice.deliverymanagercompany.application.result.DeliveryManagerCompanyInfoResult;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.entity.DeliveryManagerCompany;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.repository.DeliveryManagerCompanyRepository;
 import com.winner.client.global.exception.BusinessException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class DeliveryManagerCompanyWriteService {
 
 	private final DeliveryManagerCompanyRepository repository;
@@ -33,5 +37,13 @@ public class DeliveryManagerCompanyWriteService {
 			repository.save(
 				DeliveryManagerCompany.create(command.userId(), command.hubId(), nextAssignmentOrder, curCount)
 			));
+	}
+
+	public DeliveryManagerCompanyInfoResult switchStatus(UUID id) {
+		DeliveryManagerCompany deliveryManagerCompany = repository.findById(id).orElseThrow(
+				() -> new BusinessException(NOT_FOUND_COMPANY_DELIVERY_MANAGER)
+			);
+		deliveryManagerCompany.switchStatus();
+		return DeliveryManagerCompanyInfoResult.from(deliveryManagerCompany);
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
@@ -80,6 +80,13 @@ public class DeliveryManagerCompany extends BaseAuditEntity {
 		this.hubId = new HubId(newHubId);
 	}
 
+	public void switchStatus() {
+		switch (this.deliveryManagerStatus) {
+			case AVAILABLE -> this.deliveryManagerStatus = DeliveryManagerStatus.OFF_DUTY;
+			case OFF_DUTY -> this.deliveryManagerStatus = DeliveryManagerStatus.AVAILABLE;
+		}
+	}
+
 	public UUID getUserId() { return userId.getValue(); }
 	public UUID getHubId() { return hubId.getValue(); }
 	public Long getAssignmentOrder() { return assignmentOrder.getValue(); }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
@@ -1,5 +1,6 @@
 package com.winner.client.deliveryservice.deliverymanagercompany.domain.entity;
 
+import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.DELIVERY_MANAGER_IN_PROGRESS;
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.EXCEEDED_TO_IN_HUB_DELIVERY_MANAGER;
 
 import com.winner.client.deliveryservice.common.constants.DeliveryManagerStatus;
@@ -85,6 +86,14 @@ public class DeliveryManagerCompany extends BaseAuditEntity {
 			case AVAILABLE -> this.deliveryManagerStatus = DeliveryManagerStatus.OFF_DUTY;
 			case OFF_DUTY -> this.deliveryManagerStatus = DeliveryManagerStatus.AVAILABLE;
 		}
+	}
+
+	@Override
+	public void softDelete(UUID userId) {
+		if (this.deliveryManagerStatus ==  DeliveryManagerStatus.IN_DELIVERY) {
+			throw new BusinessException(DELIVERY_MANAGER_IN_PROGRESS);
+		}
+		super.softDelete(userId);
 	}
 
 	public UUID getUserId() { return userId.getValue(); }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/repository/DeliveryManagerCompanyRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/repository/DeliveryManagerCompanyRepository.java
@@ -11,4 +11,5 @@ public interface DeliveryManagerCompanyRepository {
 	Optional<DeliveryManagerCompany> findLastAssignmentOrderByHubId(UUID hubId);
 	Long countByHubId(UUID hubId);
 	Optional<DeliveryManagerCompany> findById(UUID userId);
+	Optional<DeliveryManagerCompany> findByUserId(UUID userId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/DeliveryManagerCompanyJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/DeliveryManagerCompanyJpaRepository.java
@@ -39,4 +39,9 @@ public class DeliveryManagerCompanyJpaRepository implements
 	public Optional<DeliveryManagerCompany> findById(UUID id) {
 		return jpaRepository.findById(id);
 	}
+
+	@Override
+	public Optional<DeliveryManagerCompany> findByUserId(UUID userId) {
+		return jpaRepository.findByUserId_Value(userId);
+	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/SpringDataDeliveryManagerRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/SpringDataDeliveryManagerRepository.java
@@ -12,4 +12,5 @@ public interface SpringDataDeliveryManagerRepository
 	Optional<DeliveryManagerCompany> findTopByHubId_ValueOrderByAssignmentOrder_ValueDesc(UUID hubId);
 	boolean existsByUserId_Value(UUID userId);
 	Long countByHubId_Value(UUID hubId);
+	Optional<DeliveryManagerCompany> findByUserId_Value(UUID userId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
@@ -3,12 +3,14 @@ package com.winner.client.deliveryservice.deliverymanagercompany.presentation.ap
 import static com.winner.client.global.response.CommonSuccessCode.OK;
 
 import com.winner.client.deliveryservice.deliverymanagercompany.application.DeliveryManagerCompanyReadService;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.DeliveryManagerCompanyWriteService;
 import com.winner.client.deliveryservice.deliverymanagercompany.presentation.responses.DeliveryManagerCompanyInfo;
 import com.winner.client.global.response.ApiResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class DeliveryManagerCompanyController {
 
 	private final DeliveryManagerCompanyReadService deliveryManagerCompanyReadService;
+	private final DeliveryManagerCompanyWriteService deliveryManagerCompanyWriteService;
 
 	@GetMapping("/{id}")
 	public ResponseEntity<ApiResponse<DeliveryManagerCompanyInfo>> getDeliveryManagerCompany(
@@ -28,4 +31,11 @@ public class DeliveryManagerCompanyController {
 			DeliveryManagerCompanyInfo.from(deliveryManagerCompanyReadService.getDetail(id))));
 	}
 
+	@PatchMapping("/{id}")
+	public ResponseEntity<ApiResponse<DeliveryManagerCompanyInfo>> switchStatus(
+		@PathVariable UUID id
+	) {
+		return ResponseEntity.ok().body(ApiResponse.success(OK,
+			DeliveryManagerCompanyInfo.from(deliveryManagerCompanyWriteService.switchStatus(id))));
+	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/internal/InternalDeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/internal/InternalDeliveryManagerCompanyController.java
@@ -5,8 +5,12 @@ import com.winner.client.deliveryservice.deliverymanagercompany.presentation.req
 import com.winner.client.deliveryservice.deliverymanagercompany.presentation.responses.DeliveryManagerCompanyInfo;
 import com.winner.client.global.response.ApiResponse;
 import com.winner.client.global.response.CommonSuccessCode;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +34,15 @@ public class InternalDeliveryManagerCompanyController {
 					deliveryManagerCompanyWriteService.registration(
 						DeliveryManagerCompanyRegistrationRequest.toCommand(request.userId(),
 							request.hubId())))));
+	}
+
+	@DeleteMapping("/{userId}")
+	public ResponseEntity<ApiResponse<Void>> deactivate(
+		@PathVariable UUID userId
+	) {
+		deliveryManagerCompanyWriteService.deactivate(userId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(
+			ApiResponse.success(CommonSuccessCode.DELETED, null)
+		);
 	}
 }


### PR DESCRIPTION
### 📎 관련 이슈
- closes #25

### 📌 작업 내용
- 배송 담당자(DeliveryManagerCompany)의 업무 상태(출근/휴무) 전환 및 계정 비활성화 기능 구현
- Soft Delete 적용

### ✨ 변경 사항
- **상태 전환 및 비활성화 로직**:
    - `switchStatus`: 배송담당자 상태 변경을 위한 엔드포인트 추가
    - `deactivate`: 배송 담당자 권한을 해제하거나 비활성화하는 전용 메서드 및 엔드포인트 추가
- **Soft Delete 구현**: 
    - 엔티티 삭제 시 물리적 삭제 대신 상태값을 변경하는 `softDelete` 메서드를 오버라이드하여 비즈니스 요구사항에 맞게 구현
- **서비스 및 컨트롤러**: 
    - `DeliveryManagerCompanyService` 내 `@Transactional`을 통한 원자성 보장
    - `PATCH /api/v1/delivery-managers/company/{id}` 엔드포인트를 통한 상태 제어 기능 연결
    - `DELETE/internal/v1/delivery-managers/company/{id}` 엔드포인트를 통한 배송담당자 비활성화 기능 연결

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항
- 배송 담당자의 정보 업데이트 범위가 아직 확정되지 않아, 우선적으로 비즈니스 영향도가 높은 상태 관리 및 활성화 여부를 중심으로 API를 만들었습니다.
- 향후 상세 정보(배정 순서 등) 수정 기능이 확정되면 해당 엔드포인트를 확장할 예정입니다.