### PR TITLE
[feat] 허브 간 최단 경로 탐색 기능 구현 (Dijkstra + 경로 복원)

### DIFF
--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubPathService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubPathService.java
@@ -2,7 +2,12 @@ package com.winner.client.hubservice.hub.application;
 
 import com.winner.client.hubservice.hub.domain.graph.DijkstraPathFinder;
 import com.winner.client.hubservice.hub.domain.graph.HubGraph;
+import com.winner.client.hubservice.hub.domain.repository.HubRepository;
 import com.winner.client.hubservice.hub.infrastructure.graph.HubGraphBuilder;
+import com.winner.client.hubservice.hub.presentation.dto.HubNodeResponse;
+import com.winner.client.hubservice.hub.presentation.dto.ShortestPathResponse;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,13 +17,36 @@ import org.springframework.stereotype.Service;
 public class HubPathService {
 
     private final HubGraphBuilder graphBuilder;
+    private final HubRepository hubRepository;
 
-    public DijkstraPathFinder.Result findShortestPath(UUID from, UUID to) {
+    public ShortestPathResponse findShortestPath(UUID from, UUID to) {
 
         HubGraph graph = graphBuilder.build();
 
         DijkstraPathFinder dijkstra = new DijkstraPathFinder();
+        DijkstraPathFinder.Result result =
+            dijkstra.findShortestPath(graph, from, to);
 
-        return dijkstra.findShortestPath(graph, from, to);
+        List<HubNodeResponse> nodes = new ArrayList<>();
+
+        int sequence = 1;
+
+        for (UUID hubId : result.path) {
+
+            String hubName = hubRepository.findById(hubId)
+                .map(hub -> hub.getName())
+                .orElse("UNKNOWN");
+
+            nodes.add(new HubNodeResponse(
+                hubId,
+                hubName,
+                sequence++
+            ));
+        }
+
+        return new ShortestPathResponse(
+            nodes.size(),
+            nodes
+        );
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubPathService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubPathService.java
@@ -3,7 +3,6 @@ package com.winner.client.hubservice.hub.application;
 import com.winner.client.hubservice.hub.domain.graph.DijkstraPathFinder;
 import com.winner.client.hubservice.hub.domain.graph.HubGraph;
 import com.winner.client.hubservice.hub.infrastructure.graph.HubGraphBuilder;
-import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,13 +13,12 @@ public class HubPathService {
 
     private final HubGraphBuilder graphBuilder;
 
-    public double findShortestDistance(UUID from, UUID to) {
+    public DijkstraPathFinder.Result findShortestPath(UUID from, UUID to) {
 
         HubGraph graph = graphBuilder.build();
 
         DijkstraPathFinder dijkstra = new DijkstraPathFinder();
-        Map<UUID, Double> distances = dijkstra.findShortestDistances(graph, from);
 
-        return distances.getOrDefault(to, -1.0);
+        return dijkstra.findShortestPath(graph, from, to);
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubPathService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubPathService.java
@@ -1,0 +1,26 @@
+package com.winner.client.hubservice.hub.application;
+
+import com.winner.client.hubservice.hub.domain.graph.DijkstraPathFinder;
+import com.winner.client.hubservice.hub.domain.graph.HubGraph;
+import com.winner.client.hubservice.hub.infrastructure.graph.HubGraphBuilder;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HubPathService {
+
+    private final HubGraphBuilder graphBuilder;
+
+    public double findShortestDistance(UUID from, UUID to) {
+
+        HubGraph graph = graphBuilder.build();
+
+        DijkstraPathFinder dijkstra = new DijkstraPathFinder();
+        Map<UUID, Double> distances = dijkstra.findShortestDistances(graph, from);
+
+        return distances.getOrDefault(to, -1.0);
+    }
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/graph/DijkstraPathFinder.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/graph/DijkstraPathFinder.java
@@ -1,0 +1,48 @@
+package com.winner.client.hubservice.hub.domain.graph;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.UUID;
+
+public class DijkstraPathFinder {
+
+    public Map<UUID, Double> findShortestDistances(HubGraph graph, UUID start) {
+
+        Map<UUID, Double> distance = new HashMap<>();
+        PriorityQueue<Node> pq = new PriorityQueue<>(Comparator.comparingDouble(n -> n.dist));
+
+        distance.put(start, 0.0);
+        pq.offer(new Node(start, 0.0));
+
+        while (!pq.isEmpty()) {
+            Node current = pq.poll();
+
+            if (current.dist > distance.getOrDefault(current.id, Double.MAX_VALUE)) {
+                continue;
+            }
+
+            for (HubEdge edge : graph.getEdges(current.id)) {
+                double newDist = current.dist + edge.getDistance();
+
+                if (newDist < distance.getOrDefault(edge.getTo(), Double.MAX_VALUE)) {
+                    distance.put(edge.getTo(), newDist);
+                    pq.offer(new Node(edge.getTo(), newDist));
+                }
+            }
+        }
+
+        return distance;
+    }
+
+    static class Node {
+        UUID id;
+        double dist;
+
+        public Node(UUID id, double dist) {
+            this.id = id;
+            this.dist = dist;
+        }
+    }
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/graph/DijkstraPathFinder.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/graph/DijkstraPathFinder.java
@@ -1,16 +1,21 @@
 package com.winner.client.hubservice.hub.domain.graph;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.UUID;
 
 public class DijkstraPathFinder {
 
-    public Map<UUID, Double> findShortestDistances(HubGraph graph, UUID start) {
+    public Result findShortestPath(HubGraph graph, UUID start, UUID end) {
 
         Map<UUID, Double> distance = new HashMap<>();
+        Map<UUID, UUID> prev = new HashMap<>();
+
         PriorityQueue<Node> pq = new PriorityQueue<>(Comparator.comparingDouble(n -> n.dist));
 
         distance.put(start, 0.0);
@@ -23,17 +28,43 @@ public class DijkstraPathFinder {
                 continue;
             }
 
+            if (current.id.equals(end)) {
+                break;
+            }
+
             for (HubEdge edge : graph.getEdges(current.id)) {
                 double newDist = current.dist + edge.getDistance();
 
                 if (newDist < distance.getOrDefault(edge.getTo(), Double.MAX_VALUE)) {
                     distance.put(edge.getTo(), newDist);
+                    prev.put(edge.getTo(), current.id);
                     pq.offer(new Node(edge.getTo(), newDist));
                 }
             }
         }
 
-        return distance;
+        List<UUID> path = new ArrayList<>();
+        UUID cur = end;
+
+        while (cur != null) {
+            path.add(cur);
+            cur = prev.get(cur);
+        }
+
+        Collections.reverse(path);
+
+        return new Result(path, distance.getOrDefault(end, -1.0));
+    }
+
+    public static class Result {
+
+        public final List<UUID> path;
+        public final double distance;
+
+        public Result(List<UUID> path, double distance) {
+            this.path = path;
+            this.distance = distance;
+        }
     }
 
     static class Node {

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/graph/HubEdge.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/graph/HubEdge.java
@@ -1,0 +1,22 @@
+package com.winner.client.hubservice.hub.domain.graph;
+
+import java.util.UUID;
+
+public class HubEdge {
+
+    private final UUID to;
+    private final double distance;
+
+    public HubEdge(UUID to, double distance) {
+        this.to = to;
+        this.distance = distance;
+    }
+
+    public UUID getTo() {
+        return to;
+    }
+
+    public double getDistance() {
+        return distance;
+    }
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/graph/HubGraph.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/graph/HubGraph.java
@@ -1,0 +1,26 @@
+package com.winner.client.hubservice.hub.domain.graph;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public class HubGraph {
+
+    private final Map<UUID, List<HubEdge>> adjacencyList = new HashMap<>();
+
+    public void addEdge(UUID from, HubEdge edge) {
+        adjacencyList.computeIfAbsent(from, k -> new ArrayList<>()).add(edge);
+    }
+
+    public List<HubEdge> getEdges(UUID from) {
+        return adjacencyList.getOrDefault(from, Collections.emptyList());
+    }
+
+    public Set<UUID> getNodes() {
+        return adjacencyList.keySet();
+    }
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/graph/HubGraphBuilder.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/graph/HubGraphBuilder.java
@@ -1,0 +1,43 @@
+package com.winner.client.hubservice.hub.infrastructure.graph;
+
+import com.winner.client.hubservice.hub.domain.entity.HubRoute;
+import com.winner.client.hubservice.hub.domain.graph.HubEdge;
+import com.winner.client.hubservice.hub.domain.graph.HubGraph;
+import com.winner.client.hubservice.hub.domain.repository.HubRouteRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HubGraphBuilder {
+
+    private final HubRouteRepository hubRouteRepository;
+
+    public HubGraph build() {
+        List<HubRoute> routes = hubRouteRepository.findAll();
+
+        HubGraph graph = new HubGraph();
+
+        for (HubRoute route : routes) {
+            var routeInfo = route.getRouteInfo();
+
+            var from = routeInfo.getFromHubId();
+            var to = routeInfo.getToHubId();
+
+            double distance = route.getDistance().getValue();
+
+            graph.addEdge(
+                from,
+                new HubEdge(to, distance)
+            );
+
+            graph.addEdge(
+                to,
+                new HubEdge(from, distance)
+            );
+        }
+
+        return graph;
+    }
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/InternalHubRouteController.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/InternalHubRouteController.java
@@ -1,11 +1,16 @@
 package com.winner.client.hubservice.hub.presentation;
 
+import com.winner.client.hubservice.hub.application.HubPathService;
 import com.winner.client.hubservice.hub.application.HubRouteService;
 import com.winner.client.hubservice.hub.application.dto.HubRouteResult;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -13,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class InternalHubRouteController {
 
     private final HubRouteService hubRouteService;
+    private final HubPathService hubPathService;
 
     @GetMapping
     public List<HubRouteResult> getRoutes(
@@ -20,5 +26,13 @@ public class InternalHubRouteController {
         @RequestParam UUID toHubId
     ) {
         return hubRouteService.searchRoutes(fromHubId, toHubId);
+    }
+
+    @GetMapping("/shortest")
+    public ResponseEntity<Double> getShortestPath(
+        @RequestParam UUID from,
+        @RequestParam UUID to
+    ) {
+        return ResponseEntity.ok(hubPathService.findShortestDistance(from, to));
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/InternalHubRouteController.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/InternalHubRouteController.java
@@ -29,10 +29,10 @@ public class InternalHubRouteController {
     }
 
     @GetMapping("/shortest")
-    public ResponseEntity<Double> getShortestPath(
+    public ResponseEntity<?> getShortestPath(
         @RequestParam UUID from,
         @RequestParam UUID to
     ) {
-        return ResponseEntity.ok(hubPathService.findShortestDistance(from, to));
+        return ResponseEntity.ok(hubPathService.findShortestPath(from, to));
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/InternalHubRouteController.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/InternalHubRouteController.java
@@ -3,6 +3,7 @@ package com.winner.client.hubservice.hub.presentation;
 import com.winner.client.hubservice.hub.application.HubPathService;
 import com.winner.client.hubservice.hub.application.HubRouteService;
 import com.winner.client.hubservice.hub.application.dto.HubRouteResult;
+import com.winner.client.hubservice.hub.presentation.dto.ShortestPathResponse;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ public class InternalHubRouteController {
     }
 
     @GetMapping("/shortest")
-    public ResponseEntity<?> getShortestPath(
+    public ResponseEntity<ShortestPathResponse> getShortestPath(
         @RequestParam UUID from,
         @RequestParam UUID to
     ) {

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/dto/HubNodeResponse.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/dto/HubNodeResponse.java
@@ -1,0 +1,14 @@
+package com.winner.client.hubservice.hub.presentation.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class HubNodeResponse {
+
+    private UUID hubId;
+    private String hubName;
+    private int sequence;
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/dto/ShortestPathResponse.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/dto/ShortestPathResponse.java
@@ -1,0 +1,13 @@
+package com.winner.client.hubservice.hub.presentation.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ShortestPathResponse {
+
+    private int count;
+    private List<HubNodeResponse> nodes;
+}

--- a/hub-service/src/main/resources/application.yaml
+++ b/hub-service/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ spring:
     password: ${POSTGRES_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     defer-datasource-initialization: true
     show-sql: false
     open-in-view: false
@@ -21,7 +21,7 @@ spring:
         jdbc.time_zone: Asia/Seoul
   sql:
     init:
-      mode: always
+      mode: never
 
 eureka:
   client:


### PR DESCRIPTION
### 📎 관련 이슈
- close #70 

### 📌 작업 내용
- 허브 간 이동 경로 탐색을 위한 Dijkstra 알고리즘 구현
- 출발 허브 → 도착 허브까지 최단 거리 계산 기능 구현
- HubRoute 데이터를 기반으로 그래프(Adjacency List) 구성
- 최단 경로에 대한 경로 복원(path reconstruction) 기능 추가
- internal API(`/internal/v1/hub-routes/shortest`)를 통해 외부 서비스에서 호출 가능하도록 구현

### ✨ 변경 사항
- DijkstraPathFinder: 최단 거리 계산 → 경로 복원 기능 확장
- HubPathService: 거리 반환 → 경로 + 거리 반환 구조로 변경
- InternalHubRouteController: API 응답 구조 변경 (distance → path + distance)
- application.yml: `ddl-auto: update`로 변경하여 DB 데이터 유지하도록 설정

### 📝 리뷰 포인트
- Dijkstra 알고리즘 구현 및 경로 복원 로직의 적절성
- HubRoute → Graph 변환 구조 (Adjacency List) 설계
- Service 계층에서의 책임 분리 및 의존성 구조
- internal API 설계가 타 서비스에서 활용하기 적절한지

### 🧠 기타 참고 사항
- 현재 distance 값은 DB에 저장된 값을 기준으로 계산하며, 추후 API 연동을 통해 실제 거리 및 소요 시간 기반으로 확장 예정
- Redis 캐싱을 통한 경로 조회 성능 개선 고려 가능
<img width="1574" height="514" alt="image" src="https://github.com/user-attachments/assets/1707af2c-753d-4825-8623-f072057c2dbe" />
