### PR TITLE
feat: 허브 배송 담당자 R U D 기능 개발

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/hub/DeliveryManagerHubErrorCode.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/hub/DeliveryManagerHubErrorCode.java
@@ -12,6 +12,10 @@ public enum DeliveryManagerHubErrorCode implements ErrorCode {
 		"이미 등록 된 업체 배송 담당자 입니다."),
 	HUB_DELIVERY_MANAGER_OVER_CAPACITY("ERROR_652", HttpStatus.CONFLICT,
 		"허브 배송 담당자 정원 초과"),
+	NOT_FOUND_HUB_DELIVERY_MANAGER("ERROR_653", HttpStatus.NOT_FOUND,
+		"존재하지 않는 허브배송담당자 입니다."),
+	DELIVERY_MANAGER_IN_PROGRESS("ERROR_654", HttpStatus.BAD_REQUEST,
+		"업무 진행 중엔 탈퇴가 불가능 합니다.")
 	;
 
 	private final String code;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubReadService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubReadService.java
@@ -1,0 +1,25 @@
+package com.winner.client.deliveryservice.deliverymanagerhub.application;
+
+import static com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode.NOT_FOUND_HUB_DELIVERY_MANAGER;
+
+import com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode;
+import com.winner.client.deliveryservice.deliverymanagerhub.application.result.DeliveryManagerHubInfoResult;
+import com.winner.client.deliveryservice.deliverymanagerhub.domain.repository.DeliveryManagerHubRepository;
+import com.winner.client.global.exception.BusinessException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeliveryManagerHubReadService {
+
+	private final DeliveryManagerHubRepository repository;
+
+	public DeliveryManagerHubInfoResult getDetail(UUID userId) {
+		return DeliveryManagerHubInfoResult.from(repository.findByUserId(userId)
+			.orElseThrow(() -> new BusinessException(NOT_FOUND_HUB_DELIVERY_MANAGER)));
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubReadService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubReadService.java
@@ -2,7 +2,6 @@ package com.winner.client.deliveryservice.deliverymanagerhub.application;
 
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode.NOT_FOUND_HUB_DELIVERY_MANAGER;
 
-import com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.result.DeliveryManagerHubInfoResult;
 import com.winner.client.deliveryservice.deliverymanagerhub.domain.repository.DeliveryManagerHubRepository;
 import com.winner.client.global.exception.BusinessException;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubWriteService.java
@@ -1,17 +1,21 @@
 package com.winner.client.deliveryservice.deliverymanagerhub.application;
 
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode.ALREADY_REGISTERED_HUB_DELIVERY_MANAGER;
+import static com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode.NOT_FOUND_HUB_DELIVERY_MANAGER;
 
 import com.winner.client.deliveryservice.deliverymanagerhub.application.commnad.DeliveryManagerHubRegistrationCommand;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.result.DeliveryManagerHubInfoResult;
 import com.winner.client.deliveryservice.deliverymanagerhub.domain.entity.DeliveryManagerHub;
 import com.winner.client.deliveryservice.deliverymanagerhub.domain.repository.DeliveryManagerHubRepository;
 import com.winner.client.global.exception.BusinessException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class DeliveryManagerHubWriteService {
 
 	private final DeliveryManagerHubRepository repository;
@@ -34,5 +38,19 @@ public class DeliveryManagerHubWriteService {
 				DeliveryManagerHub.create(command.userId(), nextAssignmentOrder, curCount)
 			)
 		);
+	}
+
+	public DeliveryManagerHubInfoResult switchStatus(UUID userId) {
+		DeliveryManagerHub deliveryManagerHub = repository.findByUserId(userId)
+			.orElseThrow(() -> new BusinessException(NOT_FOUND_HUB_DELIVERY_MANAGER));
+
+		deliveryManagerHub.switchStatus();
+		return DeliveryManagerHubInfoResult.from(deliveryManagerHub);
+	}
+
+	public void deactivate(UUID userId) {
+		DeliveryManagerHub deliveryManagerHub = repository.findByUserId(userId)
+			.orElseThrow(() -> new BusinessException(NOT_FOUND_HUB_DELIVERY_MANAGER));
+		deliveryManagerHub.softDelete(userId);
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/domain/entity/DeliveryManagerHub.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/domain/entity/DeliveryManagerHub.java
@@ -1,5 +1,6 @@
 package com.winner.client.deliveryservice.deliverymanagerhub.domain.entity;
 
+import static com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode.DELIVERY_MANAGER_IN_PROGRESS;
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode.HUB_DELIVERY_MANAGER_OVER_CAPACITY;
 
 import com.winner.client.deliveryservice.common.constants.DeliveryManagerStatus;
@@ -77,6 +78,21 @@ public class DeliveryManagerHub extends BaseAuditEntity {
 		this.lastDeliveryCompletedTime = LocalDateTime.now();
 		this.deliveryManagerStatus = DeliveryManagerStatus.AVAILABLE;
 		this.deliveryId = new DeliveryId(null);
+	}
+
+	public void switchStatus() {
+		switch (this.deliveryManagerStatus) {
+			case AVAILABLE -> this.deliveryManagerStatus = DeliveryManagerStatus.OFF_DUTY;
+			case OFF_DUTY -> this.deliveryManagerStatus = DeliveryManagerStatus.AVAILABLE;
+		}
+	}
+
+	@Override
+	public void softDelete(UUID userId) {
+		if (this.deliveryManagerStatus == DeliveryManagerStatus.IN_DELIVERY) {
+			throw new BusinessException(DELIVERY_MANAGER_IN_PROGRESS);
+		}
+		super.softDelete(userId);
 	}
 
 	public UUID getUserId() { return userId.getValue(); }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/domain/repository/DeliveryManagerHubRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/domain/repository/DeliveryManagerHubRepository.java
@@ -10,4 +10,5 @@ public interface DeliveryManagerHubRepository {
 	boolean existByUserId(UUID userId);
 	Long countByDeletedByIsNull();
 	Optional<DeliveryManagerHub> findFirstByOrderByAssignmentOrderDesc();
+	Optional<DeliveryManagerHub> findByUserId(UUID userId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/domain/vo/DeliveryManagerUserId.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/domain/vo/DeliveryManagerUserId.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class DeliveryManagerUserId {
 
-	@Column(name = "delivery_manager_id", nullable = false)
+	@Column(name = "user_id", nullable = false)
 	private UUID value;
 
 	public DeliveryManagerUserId(UUID value) {

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/DeliveryManagerHubJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/DeliveryManagerHubJpaRepository.java
@@ -32,4 +32,9 @@ public class DeliveryManagerHubJpaRepository implements DeliveryManagerHubReposi
 	public Optional<DeliveryManagerHub> findFirstByOrderByAssignmentOrderDesc() {
 		return repository.findFirstByOrderByAssignmentOrder_ValueDesc();
 	}
+
+	@Override
+	public Optional<DeliveryManagerHub> findByUserId(UUID userId) {
+		return repository.findByUserId_ValueAndDeletedByNull(userId);
+	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/SpringDataDeliveryManagerHubRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/SpringDataDeliveryManagerHubRepository.java
@@ -10,4 +10,5 @@ public interface SpringDataDeliveryManagerHubRepository extends JpaRepository<De
 	boolean existsByUserId_Value(UUID userId);
 	Optional<DeliveryManagerHub> findFirstByOrderByAssignmentOrder_ValueDesc();
 	Long countByDeletedByIsNull();
+	Optional<DeliveryManagerHub> findByUserId_ValueAndDeletedByNull(UUID userId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/presentation/api/DeliveryManagerHubController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/presentation/api/DeliveryManagerHubController.java
@@ -1,0 +1,42 @@
+package com.winner.client.deliveryservice.deliverymanagerhub.presentation.api;
+
+import static com.winner.client.global.response.CommonSuccessCode.OK;
+
+import com.winner.client.deliveryservice.deliverymanagerhub.application.DeliveryManagerHubReadService;
+import com.winner.client.deliveryservice.deliverymanagerhub.application.DeliveryManagerHubWriteService;
+import com.winner.client.deliveryservice.deliverymanagerhub.presentation.responses.DeliveryManagerHubInfo;
+import com.winner.client.global.response.ApiResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/delivery-managers/hub")
+public class DeliveryManagerHubController {
+
+	private final DeliveryManagerHubWriteService deliveryManagerHubWriteService;
+	private final DeliveryManagerHubReadService deliveryManagerHubReadService;
+
+	@GetMapping("/{userId}")
+	public ResponseEntity<ApiResponse<DeliveryManagerHubInfo>> getDeliveryManagerHub(
+		@PathVariable UUID userId
+	) {
+		return ResponseEntity.ok()
+			.body(ApiResponse.success(OK,
+				DeliveryManagerHubInfo.from(deliveryManagerHubReadService.getDetail(userId))));
+	}
+
+	@PatchMapping("/{userId}")
+	public ResponseEntity<ApiResponse<DeliveryManagerHubInfo>> switchStatus(
+		@PathVariable UUID userId
+	) {
+		return ResponseEntity.ok().body(ApiResponse.success(OK,
+			DeliveryManagerHubInfo.from(deliveryManagerHubWriteService.switchStatus(userId))));
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/presentation/internal/InternalDeliveryManagerHubController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/presentation/internal/InternalDeliveryManagerHubController.java
@@ -5,8 +5,11 @@ import com.winner.client.deliveryservice.deliverymanagerhub.presentation.request
 import com.winner.client.deliveryservice.deliverymanagerhub.presentation.responses.DeliveryManagerHubInfo;
 import com.winner.client.global.response.ApiResponse;
 import com.winner.client.global.response.CommonSuccessCode;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +32,15 @@ public class InternalDeliveryManagerHubController {
 					DeliveryManagerHubInfo.from(
 					deliveryManagerHubWriteService.registration(
 						DeliveryManagerHubRegistrationRequest.toCommand(request.userId())))));
+	}
+
+	@DeleteMapping("/{userId}")
+	public ResponseEntity<ApiResponse<Void>> deactivate(
+		@PathVariable UUID userId
+	) {
+		deliveryManagerHubWriteService.deactivate(userId);
+		return ResponseEntity.status(CommonSuccessCode.DELETED.getStatus()).body(
+			ApiResponse.success(CommonSuccessCode.DELETED, null)
+		);
 	}
 }


### PR DESCRIPTION
### 📎 관련 이슈
- closes #25

### 📌 작업 내용
- 허브 배송 담당자(DeliveryManagerHub)에 대한 조회, 수정, 삭제(RUD) 기능 구현
- 비즈니스 예외 상황 처리를 위한 전용 에러 코드 생성
- 배송 업무 상태에 따른 상태 전환 및 삭제 제한 로직 추가

### ✨ 변경 사항
- **RUD 엔드포인트 및 서비스**:
    - `DeliveryManagerHubController`: 단건 상세 조회, 상태 수정, 비활성화를 위한 API 엔드포인트 추가
    - `DeliveryManagerHubReadService`: 허브 배송 담당자 정보 조회 로직 개발
    - `DeliveryManagerHubWriteService`: 상태 전환(switchStatus) 및 비활성화 메서드 확장
- **비즈니스 예외 코드 추가**:
    - `NOT_FOUND_HUB_DELIVERY_MANAGER`: 존재하지 않는 허브 배송 담당자 조회 시 발생
    - `DELIVERY_MANAGER_IN_PROGRESS`: 배송 중인 담당자에 대한 제한 작업 시 발생
- **도메인 로직 고도화**:
    - `switchStatus`: `AVAILABLE`(대기)과 `OFF_DUTY`(휴무) 간의 상태 전환 기능 구현
    - `softDelete` 로직 강화: 현재 배송 중(`IN_DELIVERY`)인 담당자는 삭제(비활성화)할 수 없도록 검증 로직 추가
- **내부 API 확장**:
    - `InternalDeliveryManagerHubController`: 서비스 간 통신을 위한 배송담당자 삭제 엔드포인트 추가

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항

- 도메인 분리 의도: 

업체 배송담당자 & 허브 배송담당자 가 현재는 hubId를 가지고 있냐 or 없냐 차이만 있어서 많은 부분이 중복되지만 이는 현재 과제의 어색한 요구사항 때문에 생긴 우연의 일치라고 판단했고, 후에 도메인이 확장됨에 있어서 유연하게 대처하게 위해 중복코드를 따로 빼지않고 각각 처리했습니다.