### PR TITLE
[refactor]: 업체 배송 담당자 조회 메서드 결과에서 삭제된 데이터 제외

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyReadService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyReadService.java
@@ -17,8 +17,8 @@ public class DeliveryManagerCompanyReadService {
 
 	private final DeliveryManagerCompanyRepository repository;
 
-	public DeliveryManagerCompanyInfoResult getDetail(UUID id) {
-		return DeliveryManagerCompanyInfoResult.from(repository.findById(id).orElseThrow(
+	public DeliveryManagerCompanyInfoResult getDetail(UUID userId) {
+		return DeliveryManagerCompanyInfoResult.from(repository.findByUserIdAndDeletedByNull(userId).orElseThrow(
 			() -> new BusinessException(NOT_FOUND_COMPANY_DELIVERY_MANAGER)
 		));
 	}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
@@ -39,8 +39,8 @@ public class DeliveryManagerCompanyWriteService {
 			));
 	}
 
-	public DeliveryManagerCompanyInfoResult switchStatus(UUID id) {
-		DeliveryManagerCompany deliveryManagerCompany = repository.findById(id).orElseThrow(
+	public DeliveryManagerCompanyInfoResult switchStatus(UUID userId) {
+		DeliveryManagerCompany deliveryManagerCompany = repository.findByUserIdAndDeletedByNull(userId).orElseThrow(
 				() -> new BusinessException(NOT_FOUND_COMPANY_DELIVERY_MANAGER)
 			);
 		deliveryManagerCompany.switchStatus();
@@ -48,7 +48,7 @@ public class DeliveryManagerCompanyWriteService {
 	}
 
 	public void deactivate(UUID userId) {
-		DeliveryManagerCompany deliveryManagerCompany = repository.findByUserId(userId)
+		DeliveryManagerCompany deliveryManagerCompany = repository.findByUserIdAndDeletedByNull(userId)
 			.orElseThrow(() -> new BusinessException(NOT_FOUND_COMPANY_DELIVERY_MANAGER));
 		deliveryManagerCompany.softDelete(userId);
 	}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/repository/DeliveryManagerCompanyRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/repository/DeliveryManagerCompanyRepository.java
@@ -10,6 +10,5 @@ public interface DeliveryManagerCompanyRepository {
 	boolean existByUserId(UUID userId);
 	Optional<DeliveryManagerCompany> findLastAssignmentOrderByHubId(UUID hubId);
 	Long countByHubId(UUID hubId);
-	Optional<DeliveryManagerCompany> findById(UUID userId);
-	Optional<DeliveryManagerCompany> findByUserId(UUID userId);
+	Optional<DeliveryManagerCompany> findByUserIdAndDeletedByNull(UUID userId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/DeliveryManagerCompanyJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/DeliveryManagerCompanyJpaRepository.java
@@ -14,7 +14,6 @@ public class DeliveryManagerCompanyJpaRepository implements
 
 	private final SpringDataDeliveryManagerRepository jpaRepository;
 
-
 	@Override
 	public DeliveryManagerCompany save(DeliveryManagerCompany deliveryManagerCompany) {
 		return jpaRepository.save(deliveryManagerCompany);
@@ -36,12 +35,7 @@ public class DeliveryManagerCompanyJpaRepository implements
 	}
 
 	@Override
-	public Optional<DeliveryManagerCompany> findById(UUID id) {
-		return jpaRepository.findById(id);
-	}
-
-	@Override
-	public Optional<DeliveryManagerCompany> findByUserId(UUID userId) {
-		return jpaRepository.findByUserId_Value(userId);
+	public Optional<DeliveryManagerCompany> findByUserIdAndDeletedByNull(UUID userId) {
+		return jpaRepository.findByUserId_ValueAndDeletedByNull(userId);
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/SpringDataDeliveryManagerRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/SpringDataDeliveryManagerRepository.java
@@ -12,5 +12,5 @@ public interface SpringDataDeliveryManagerRepository
 	Optional<DeliveryManagerCompany> findTopByHubId_ValueOrderByAssignmentOrder_ValueDesc(UUID hubId);
 	boolean existsByUserId_Value(UUID userId);
 	Long countByHubId_ValueAndDeletedByIsNull(UUID hubId);
-	Optional<DeliveryManagerCompany> findByUserId_Value(UUID userId);
+	Optional<DeliveryManagerCompany> findByUserId_ValueAndDeletedByNull(UUID userId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
@@ -23,19 +23,19 @@ public class DeliveryManagerCompanyController {
 	private final DeliveryManagerCompanyReadService deliveryManagerCompanyReadService;
 	private final DeliveryManagerCompanyWriteService deliveryManagerCompanyWriteService;
 
-	@GetMapping("/{id}")
+	@GetMapping("/{userId}")
 	public ResponseEntity<ApiResponse<DeliveryManagerCompanyInfo>> getDeliveryManagerCompany(
-		@PathVariable UUID id
+		@PathVariable UUID userId
 	) {
 		return ResponseEntity.ok().body(ApiResponse.success(OK,
-			DeliveryManagerCompanyInfo.from(deliveryManagerCompanyReadService.getDetail(id))));
+			DeliveryManagerCompanyInfo.from(deliveryManagerCompanyReadService.getDetail(userId))));
 	}
 
-	@PatchMapping("/{id}")
+	@PatchMapping("/{userId}")
 	public ResponseEntity<ApiResponse<DeliveryManagerCompanyInfo>> switchStatus(
-		@PathVariable UUID id
+		@PathVariable UUID userId
 	) {
 		return ResponseEntity.ok().body(ApiResponse.success(OK,
-			DeliveryManagerCompanyInfo.from(deliveryManagerCompanyWriteService.switchStatus(id))));
+			DeliveryManagerCompanyInfo.from(deliveryManagerCompanyWriteService.switchStatus(userId))));
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/internal/InternalDeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/internal/InternalDeliveryManagerCompanyController.java
@@ -1,5 +1,7 @@
 package com.winner.client.deliveryservice.deliverymanagercompany.presentation.internal;
 
+import static com.winner.client.global.response.CommonSuccessCode.DELETED;
+
 import com.winner.client.deliveryservice.deliverymanagercompany.application.DeliveryManagerCompanyWriteService;
 import com.winner.client.deliveryservice.deliverymanagercompany.presentation.requests.DeliveryManagerCompanyRegistrationRequest;
 import com.winner.client.deliveryservice.deliverymanagercompany.presentation.responses.DeliveryManagerCompanyInfo;
@@ -41,8 +43,8 @@ public class InternalDeliveryManagerCompanyController {
 		@PathVariable UUID userId
 	) {
 		deliveryManagerCompanyWriteService.deactivate(userId);
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(
-			ApiResponse.success(CommonSuccessCode.DELETED, null)
+		return ResponseEntity.status(DELETED.getStatus()).body(
+			ApiResponse.success(DELETED, null)
 		);
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/internal/InternalDeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/internal/InternalDeliveryManagerCompanyController.java
@@ -9,7 +9,6 @@ import com.winner.client.global.response.ApiResponse;
 import com.winner.client.global.response.CommonSuccessCode;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;


### PR DESCRIPTION
### 📎 관련 이슈
- closes #84

### 📌 작업 내용
- 시스템 전반에서 삭제된 데이터를 제외하고 유효한 데이터만 조회되도록 리포지토리 로직 수정
- 컨트롤러 내 변수명 정리 및 응답 처리 방식의 일관성 확보를 위한 리팩토링 진행

### ✨ 변경 사항
- **Soft-Delete 필터링 적용**: `DeliveryManagerCompany`를 포함한 주요 리포지토리 쿼리에서 `deleted_by IS NULL` 조건을 추가하여 삭제된 레코드가 조회되지 않도록 수정
- **리포지토리 메서드 갱신**: 기존의 전체 조회 메서드들을 논리 삭제 조건을 포함한 메서드(예: `countBy...AndDeletedByIsNull`)로 교체
- **컨트롤러 리팩토링**: 
    - API 응답 시 반환되는 데이터 구조와 에러 핸들링 방식을 공통 컨벤션에 맞춰 재정비

### 📝 리뷰 포인트 (선택)
- **쿼리 조건 누락 여부**: 수정된 리포지토리 메서드들 중 Soft-Delete 조건이 빠진 곳은 없는지 확인 부탁드립니다.

### 🧠 기타 참고 사항
- jpa 쿼리메서드가 너무 길어서 가독성을 해친다고 느껴지시면 말씀주세요 쿼리로 작성하도록 하겠습니다.