### PR TITLE
[feat] 공통 페이징 처리 기능 구현

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRepository.java
@@ -3,13 +3,9 @@ package com.winner.client.deliveryservice.delivery.domain.repository;
 import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {
-  @Query("SELECT d FROM Delivery d JOIN FETCH d.routes WHERE d.id = :id")
-  Optional<Delivery> findByIdWithRoutes(@Param("id") UUID id);
+public interface DeliveryRepository{
+  Optional<Delivery> findByIdWithRoutes(UUID id);
+  Optional<Delivery> findById(UUID id);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRouteRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRouteRepository.java
@@ -2,11 +2,11 @@ package com.winner.client.deliveryservice.delivery.domain.repository;
 
 import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface DeliveryRouteRepository extends JpaRepository<DeliveryRoute, UUID> {
+public interface DeliveryRouteRepository {
   List<DeliveryRoute> findAllByDeliveryId(UUID deliveryId);
+  Optional<DeliveryRoute> findById(UUID id);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryJpaRepository.java
@@ -1,0 +1,25 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.repository;
+
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
+import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DeliveryJpaRepository implements DeliveryRepository {
+
+  private final SpringDataDeliveryRepository deliveryJpaRepository;
+
+  @Override
+  public Optional<Delivery> findByIdWithRoutes(UUID id) {
+    return deliveryJpaRepository.findByIdWithRoutes(id);
+  }
+
+  @Override
+  public Optional<Delivery> findById(UUID id) {
+    return deliveryJpaRepository.findById(id);
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
@@ -1,0 +1,25 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.repository;
+
+import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
+import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DeliveryRouteJpaRepository implements DeliveryRouteRepository {
+  private final SpringDataDeliveryRouteRepository routeJpaRepository;
+
+  @Override
+  public List<DeliveryRoute> findAllByDeliveryId(UUID deliveryId) {
+    return routeJpaRepository.findAllByDeliveryId(deliveryId);
+  }
+
+  @Override
+  public Optional<DeliveryRoute> findById(UUID id) {
+    return routeJpaRepository.findById(id);
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRepository.java
@@ -1,0 +1,13 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.repository;
+
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SpringDataDeliveryRepository extends JpaRepository<Delivery, UUID> {
+  @Query("SELECT d FROM Delivery d JOIN FETCH d.routes WHERE d.id = :id")
+  Optional<Delivery> findByIdWithRoutes(@Param("id") UUID id);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRouteRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRouteRepository.java
@@ -1,0 +1,10 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.repository;
+
+import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataDeliveryRouteRepository extends JpaRepository<DeliveryRoute, UUID> {
+  List<DeliveryRoute> findAllByDeliveryId(UUID deliveryId);
+}

--- a/global/build.gradle
+++ b/global/build.gradle
@@ -32,10 +32,32 @@ dependencyManagement {
     }
 }
 
+def querydslDir = "src/main/generated"
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean {
+    delete file(querydslDir)
+}
+
 dependencies {
     implementation 'org.springframework:spring-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    api "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    api "com.querydsl:querydsl-apt:5.0.0:jakarta"
+
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+    compileOnly 'org.springframework:spring-webmvc'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/global/src/main/java/com/winner/client/global/config/GlobalWebConfig.java
+++ b/global/src/main/java/com/winner/client/global/config/GlobalWebConfig.java
@@ -1,0 +1,16 @@
+package com.winner.client.global.config;
+
+import com.winner.client.global.pagination.PageRequestArgumentResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class GlobalWebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(new PageRequestArgumentResolver());
+  }
+}

--- a/global/src/main/java/com/winner/client/global/config/JpaAuditingConfig.java
+++ b/global/src/main/java/com/winner/client/global/config/JpaAuditingConfig.java
@@ -6,5 +6,4 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-@Profile("!test")
 public class JpaAuditingConfig {}

--- a/global/src/main/java/com/winner/client/global/config/QuerydslConfig.java
+++ b/global/src/main/java/com/winner/client/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.winner.client.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/global/src/main/java/com/winner/client/global/pagination/CommonPageRequest.java
+++ b/global/src/main/java/com/winner/client/global/pagination/CommonPageRequest.java
@@ -1,0 +1,32 @@
+package com.winner.client.global.pagination;
+
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Getter
+public class CommonPageRequest {
+  public static final int DEFAULT_PAGE = 0;
+  public static final int DEFAULT_SIZE = PageSizePolicy.SMALL.getSize();
+  public static final String DEFAULT_SORT = PageSortType.CREATED_AT_ASC.name();
+
+  private final int page;
+  private final int size;
+  private final String sort;
+
+  private CommonPageRequest(int page, int size, String sort) {
+    this.page = Math.max(0, page);
+    this.size = PageSizePolicy.normalize(size);  // 정책 위임
+    this.sort = PageSortType.isValidSort(sort) ? sort : DEFAULT_SORT;
+  }
+
+  public static CommonPageRequest of(
+      int page, int size, String sort) {
+    return new CommonPageRequest(page, size, sort);
+  }
+
+  public Pageable toPageable() {
+    return PageRequest.of(this.page, this.size, Sort.by(this.sort));
+  }
+}

--- a/global/src/main/java/com/winner/client/global/pagination/PageRequestArgumentResolver.java
+++ b/global/src/main/java/com/winner/client/global/pagination/PageRequestArgumentResolver.java
@@ -1,0 +1,35 @@
+package com.winner.client.global.pagination;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class PageRequestArgumentResolver implements HandlerMethodArgumentResolver {
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return CommonPageRequest.class.equals(parameter.getParameterType());
+  }
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter,
+      ModelAndViewContainer mavContainer,
+      NativeWebRequest webRequest,
+      WebDataBinderFactory binderFactory) {
+    int page = parseOrDefault(webRequest.getParameter("page"), CommonPageRequest.DEFAULT_PAGE);
+    int size = parseOrDefault(webRequest.getParameter("size"), CommonPageRequest.DEFAULT_SIZE);
+    String sort = parseOrDefault(webRequest.getParameter("sort"));
+    return CommonPageRequest.of(page, size, sort);
+  }
+
+  private int parseOrDefault(String value, int defaultValue) {
+    if (value == null) return defaultValue;
+    try { return Integer.parseInt(value); }
+    catch (NumberFormatException e) { return defaultValue; }
+  }
+
+  private String parseOrDefault(String value) {
+    return (value == null || value.isBlank()) ? CommonPageRequest.DEFAULT_SORT : value;
+  }
+}

--- a/global/src/main/java/com/winner/client/global/pagination/PageResponse.java
+++ b/global/src/main/java/com/winner/client/global/pagination/PageResponse.java
@@ -1,0 +1,30 @@
+package com.winner.client.global.pagination;
+
+import java.util.List;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+public class PageResponse<T> {
+  private final List<T> content;
+  private final int page;
+  private final int size;
+  private final long totalElements;
+  private final int totalPages;
+  private final boolean last;
+  private final boolean first;
+
+  private PageResponse(Page<T> page) {
+    this.content = page.getContent();
+    this.page = page.getNumber();
+    this.size = page.getSize();
+    this.totalElements = page.getTotalElements();
+    this.totalPages = page.getTotalPages();
+    this.last = page.isLast();
+    this.first = page.isFirst();
+  }
+
+  public static <T> PageResponse<T> of(Page<T> page) {
+    return new PageResponse<>(page);
+  }
+}

--- a/global/src/main/java/com/winner/client/global/pagination/PageSizePolicy.java
+++ b/global/src/main/java/com/winner/client/global/pagination/PageSizePolicy.java
@@ -1,0 +1,22 @@
+package com.winner.client.global.pagination;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public enum PageSizePolicy {
+  SMALL(10), MEDIUM(30), LARGE(50);
+
+  private final int size;
+  private static final Set<Integer> ALLOWED = Arrays.stream(values())
+      .map(p -> p.size)
+      .collect(Collectors.toSet());
+
+  PageSizePolicy(int size) { this.size = size; }
+
+  public static int normalize(int requested) {
+    return ALLOWED.contains(requested) ? requested : SMALL.size;
+  }
+}

--- a/global/src/main/java/com/winner/client/global/pagination/PageSortType.java
+++ b/global/src/main/java/com/winner/client/global/pagination/PageSortType.java
@@ -1,0 +1,22 @@
+package com.winner.client.global.pagination;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PageSortType {
+  CREATED_AT_ASC("createdAt", "생성일 오름차순"),
+  CREATED_AT_DESC("createdAt", "생성일 내림차순"),
+  UPDATED_AT_ASC("updatedAt", "수정일 오름차순"),
+  UPDATED_AT_DESC("updatedAt", "수정일 내림차순");
+
+  private final String property;
+  private final String description;
+
+  public static boolean isValidSort(String sort) {
+    return Arrays.stream(PageSortType.values())
+        .anyMatch(e -> e.name().equals(sort));
+  }
+}

--- a/global/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/global/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+com.winner.client.global.config.GlobalWebConfig
+com.winner.client.global.config.JpaAuditingConfig
+com.winner.client.global.config.QuerydslConfig


### PR DESCRIPTION
### 📎 관련 이슈
- close #86 

### 📌 작업 내용
- PageSizePolicy를 추가하여 페이징 사이즈 정책을 공통으로 관리하도록 구현
- PageSortType을 정의하여 정렬 기준을 enum 기반으로 표준화
- CommonPageRequest를 도입하여 컨트롤러 레벨에서 일관된 페이징 요청 객체를 사용하도록 개선
- PageResponse를 구현하여 페이징 응답 구조를 공통 포맷으로 통일
- PageRequestArgumentResolver를 적용하여 컨트롤러에서 페이징 파라미터를 자동 바인딩하도록 처리

### ✨ 변경 사항
- 페이징 요청 및 응답 구조를 공통화하여 API 일관성을 확보
- 페이징 정책(사이즈, 정렬 기준)을 중앙에서 관리할 수 있도록 개선
- 컨트롤러의 페이징 처리 로직을 단순화하고 중복 코드를 제거

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)