### PR TITLE
[feat]: 모든 배송담당자 deliveryId 필드 추가

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/result/DeliveryManagerCompanyInfoResult.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/result/DeliveryManagerCompanyInfoResult.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 public record DeliveryManagerCompanyInfoResult(
 	UUID userId,
 	UUID hubId,
+	UUID deliveryId,
 	String status,
 	Long assignmentOrder,
 	LocalDateTime lastDeliveryCompletedTime
@@ -20,6 +21,7 @@ public record DeliveryManagerCompanyInfoResult(
 		return DeliveryManagerCompanyInfoResult.builder()
 			.userId(entity.getUserId())
 			.hubId(entity.getHubId())
+			.deliveryId(entity.getDeliveryId())
 			.status(entity.getDeliveryManagerStatus().name())
 			.assignmentOrder(entity.getAssignmentOrder())
 			.lastDeliveryCompletedTime(entity.getLastDeliveryCompletedTime())

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
@@ -7,6 +7,7 @@ import com.winner.client.deliveryservice.common.constants.DeliveryManagerStatus;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.vo.AssignmentOrder;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.vo.DeliveryManagerUserId;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.vo.HubId;
+import com.winner.client.deliveryservice.deliverymanagercompany.domain.vo.DeliveryId;
 import com.winner.client.global.entity.BaseAuditEntity;
 import com.winner.client.global.exception.BusinessException;
 import jakarta.persistence.Column;
@@ -42,6 +43,9 @@ public class DeliveryManagerCompany extends BaseAuditEntity {
 	private HubId hubId;
 
 	@Embedded
+	private DeliveryId deliveryId;
+
+	@Embedded
 	private AssignmentOrder assignmentOrder;
 
 	@Getter
@@ -60,6 +64,7 @@ public class DeliveryManagerCompany extends BaseAuditEntity {
 		DeliveryManagerCompany manager = new DeliveryManagerCompany();
 		manager.userId = new DeliveryManagerUserId(userId);
 		manager.hubId = new HubId(hubId);
+		manager.deliveryId = new DeliveryId(null);
 		manager.assignmentOrder = new AssignmentOrder(assignmentOrder);
 		manager.deliveryManagerStatus = DeliveryManagerStatus.AVAILABLE;
 		return manager;
@@ -98,5 +103,6 @@ public class DeliveryManagerCompany extends BaseAuditEntity {
 
 	public UUID getUserId() { return userId.getValue(); }
 	public UUID getHubId() { return hubId.getValue(); }
+	public UUID getDeliveryId() { return deliveryId.getValue(); }
 	public Long getAssignmentOrder() { return assignmentOrder.getValue(); }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/DeliveryId.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/vo/DeliveryId.java
@@ -1,0 +1,24 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class DeliveryId {
+
+	@Column(name = "delivery_id")
+	private UUID value;
+
+	public DeliveryId(UUID value) {
+		this.value = value;
+	}
+
+	public boolean isAssigned() {
+		return value != null;
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/responses/DeliveryManagerCompanyInfo.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/responses/DeliveryManagerCompanyInfo.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 public record DeliveryManagerCompanyInfo(
 	UUID userId,
 	UUID hubId,
+	UUID deliveryId,
 	String status,
 	Long assignmentOrder,
 	LocalDateTime lastDeliveryCompletedTime
@@ -18,6 +19,7 @@ public record DeliveryManagerCompanyInfo(
 		return DeliveryManagerCompanyInfo.builder()
 			.userId(result.userId())
 			.hubId(result.hubId())
+			.deliveryId(result.deliveryId())
 			.status(result.status())
 			.assignmentOrder(result.assignmentOrder())
 			.lastDeliveryCompletedTime(result.lastDeliveryCompletedTime())

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/result/DeliveryManagerHubInfoResult.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/result/DeliveryManagerHubInfoResult.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 @Builder
 public record DeliveryManagerHubInfoResult(
 	UUID userId,
+	UUID deliveryId,
 	String status,
 	Long assignmentOrder,
 	LocalDateTime lastDeliveryCompletedTime
@@ -16,6 +17,7 @@ public record DeliveryManagerHubInfoResult(
 	public static DeliveryManagerHubInfoResult from(DeliveryManagerHub entity) {
 		return DeliveryManagerHubInfoResult.builder()
 			.userId(entity.getUserId())
+			.deliveryId(entity.getDeliveryId())
 			.status(entity.getDeliveryManagerStatus().name())
 			.assignmentOrder(entity.getAssignmentOrder())
 			.lastDeliveryCompletedTime(entity.getLastDeliveryCompletedTime())

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/presentation/responses/DeliveryManagerHubInfo.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/presentation/responses/DeliveryManagerHubInfo.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 @Builder
 public record DeliveryManagerHubInfo(
 	UUID userId,
+	UUID deliveryId,
 	String status,
 	Long assignmentOrder,
 	LocalDateTime lastDeliveryCompletedTime
@@ -16,6 +17,7 @@ public record DeliveryManagerHubInfo(
 	public static DeliveryManagerHubInfo from (DeliveryManagerHubInfoResult result) {
 		return DeliveryManagerHubInfo.builder()
 			.userId(result.userId())
+			.deliveryId(result.deliveryId())
 			.status(result.status())
 			.assignmentOrder(result.assignmentOrder())
 			.lastDeliveryCompletedTime(result.lastDeliveryCompletedTime())


### PR DESCRIPTION
### 📎 관련 이슈
- #87 

### 📌 작업 내용
- 배송 담당자 엔티티 정보에 delivery id 필드 추가

### ✨ 변경 사항
- 배송 담당자 엔티티 정보에 delivery id 필드 추가
- result, response 에도 delivery id 필드 추가

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항