### PR TITLE
[Feat] 로그인 API 구현

### DIFF
--- a/delivery-service/build.gradle
+++ b/delivery-service/build.gradle
@@ -47,6 +47,7 @@ clean {
 
 dependencies {
     implementation project(':global')
+    implementation project(path: ':global', configuration: 'querydslLib ')
     annotationProcessor project(':global')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/global/build.gradle
+++ b/global/build.gradle
@@ -21,9 +21,16 @@ configurations {
         canBeResolved = true
         canBeConsumed = true
     }
+    querydslLib {
+        canBeResolved = true
+        canBeConsumed = true
+    }
     api.extendsFrom(jwtLib)
     implementation.extendsFrom(jwtLib)
     testImplementation.extendsFrom(jwtLib)
+    api.extendsFrom(querydslLib)
+    implementation.extendsFrom(querydslLib)
+    testImplementation.extendsFrom(querydslLib)
 }
 
 dependencyManagement {
@@ -50,10 +57,9 @@ dependencies {
     implementation 'org.springframework:spring-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-    api "com.querydsl:querydsl-jpa:5.0.0:jakarta"
-    api "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    querydslLib "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    querydslLib "com.querydsl:querydsl-apt:5.0.0:jakarta"
 
-    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 
@@ -72,6 +78,7 @@ dependencies {
 
 artifacts {
     jwtLib jar
+    querydslLib jar
 }
 
 tasks.withType(Test).configureEach {

--- a/global/build.gradle
+++ b/global/build.gradle
@@ -61,9 +61,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    jwtLib 'io.jsonwebtoken:jjwt-api:0.11.5'
-    jwtLib 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    jwtLib 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    jwtLib 'io.jsonwebtoken:jjwt-api:0.12.6'
+    jwtLib 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    jwtLib 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'

--- a/global/src/main/java/com/winner/client/global/config/jwt/JwtTokenProvider.java
+++ b/global/src/main/java/com/winner/client/global/config/jwt/JwtTokenProvider.java
@@ -6,7 +6,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -33,18 +32,18 @@ public class JwtTokenProvider {
     this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
   }
 
-  public String createAccessToken(UUID userId, String role, UUID referenceId,boolean userStatus) {
+  public String createAccessToken(UUID userId, String role, UUID referenceId, boolean userStatus) {
     Date now = new Date();
     Date expirationDate = new Date(now.getTime() + accessExpirationTime);
 
     return Jwts.builder()
-        .setSubject(String.valueOf(userId))
+        .subject(String.valueOf(userId))
         .claim("role", role)
         .claim("referenceId", referenceId)
-        .claim("status",userStatus)
-        .setIssuedAt(now)
-        .setExpiration(expirationDate)
-        .signWith(secretKey, SignatureAlgorithm.HS256)
+        .claim("status", userStatus)
+        .issuedAt(now)
+        .expiration(expirationDate)
+        .signWith(secretKey)
         .compact();
   }
 
@@ -52,7 +51,7 @@ public class JwtTokenProvider {
     try {
       Date expiration = getClaims(token).getExpiration();
       long now = new Date().getTime();
-      return expiration.getTime() - now;
+      return Math.max(0, expiration.getTime() - now);
     } catch (Exception e) {
       return 0;
     }
@@ -63,24 +62,27 @@ public class JwtTokenProvider {
     Date expiryDate = new Date(now.getTime() + refreshExpirationTime);
 
     return Jwts.builder()
-        .setSubject(String.valueOf(userId))
-        .setIssuedAt(now)
-        .setExpiration(expiryDate)
-        .signWith(secretKey, SignatureAlgorithm.HS256)
+        .subject(String.valueOf(userId))
+        .issuedAt(now)
+        .expiration(expiryDate)
+        .signWith(secretKey)
         .compact();
   }
 
   public Claims getClaims(String token) {
-    return Jwts.parserBuilder()
-        .setSigningKey(secretKey)
+    return Jwts.parser()
+        .verifyWith(secretKey)
         .build()
-        .parseClaimsJws(token)
-        .getBody();
+        .parseSignedClaims(token)
+        .getPayload();
   }
 
   public boolean validateToken(String token) {
     try {
-      Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+      Jwts.parser()
+          .verifyWith(secretKey)
+          .build()
+          .parseSignedClaims(token);
       return true;
     } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
       throw new BusinessException(JwtTokenErrorCode.INVALID_SIGNATURE);

--- a/global/src/test/java/com/winner/client/global/JwtTokenProviderTest.java
+++ b/global/src/test/java/com/winner/client/global/JwtTokenProviderTest.java
@@ -14,10 +14,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 class JwtTokenProviderTest {
 
-  private JwtTokenProvider jwtTokenProvider;
-
   private final Long TEST_ACCESS_TIME = 3600000L;
   private final Long TEST_REFRESH_TIME = 604800000L;
+  private JwtTokenProvider jwtTokenProvider;
 
   @BeforeEach
   void setUp() {
@@ -41,7 +40,7 @@ class JwtTokenProviderTest {
     String role = "ROLE_USER";
     UUID referenceId = UUID.randomUUID();
 
-    String token = jwtTokenProvider.createAccessToken(userId, role, referenceId);
+    String token = jwtTokenProvider.createAccessToken(userId, role, referenceId, false);
     Claims claims = jwtTokenProvider.getClaims(token);
 
     assertThat(token).isNotNull();
@@ -53,7 +52,8 @@ class JwtTokenProviderTest {
   @Test
   @DisplayName("유효한 토큰 검증 성공")
   void validateToken_Success() {
-    String token = jwtTokenProvider.createAccessToken(UUID.randomUUID(), "USER", UUID.randomUUID());
+    String token = jwtTokenProvider.createAccessToken(UUID.randomUUID(), "USER", UUID.randomUUID(),
+        false);
     boolean isValid = jwtTokenProvider.validateToken(token);
     assertThat(isValid).isTrue();
   }
@@ -62,7 +62,8 @@ class JwtTokenProviderTest {
   @DisplayName("만료된 토큰 검증 시 예외 발생")
   void validateToken_Expired() {
     ReflectionTestUtils.setField(jwtTokenProvider, "accessExpirationTime", 0L);
-    String expiredToken = jwtTokenProvider.createAccessToken(UUID.randomUUID(), "USER", UUID.randomUUID());
+    String expiredToken = jwtTokenProvider.createAccessToken(UUID.randomUUID(), "USER",
+        UUID.randomUUID(), false);
 
     assertThatThrownBy(() -> jwtTokenProvider.validateToken(expiredToken))
         .isInstanceOf(BusinessException.class);
@@ -79,7 +80,8 @@ class JwtTokenProviderTest {
   @Test
   @DisplayName("토큰의 남은 유효 시간 계산 성공")
   void getRemainingTime_Success() {
-    String token = jwtTokenProvider.createAccessToken(UUID.randomUUID(), "USER", UUID.randomUUID());
+    String token = jwtTokenProvider.createAccessToken(UUID.randomUUID(), "USER", UUID.randomUUID(),
+        false);
 
     long remainingTime = jwtTokenProvider.getRemainingTime(token);
 

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/command/LoginCommand.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/command/LoginCommand.java
@@ -1,0 +1,7 @@
+package com.winner.client.userservice.user.application.command;
+
+public record LoginCommand(
+    String username,
+    String password) {
+
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/result/LoginResult.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/result/LoginResult.java
@@ -1,0 +1,14 @@
+package com.winner.client.userservice.user.application.result;
+
+import java.util.UUID;
+
+public record LoginResult(
+    UUID userId,
+    String accessToken,
+    String refreshToken
+) {
+
+  public static LoginResult from(UUID userId, String accessToken, String refreshToken) {
+    return new LoginResult(userId, accessToken, refreshToken);
+  }
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/service/AuthCommandService.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/service/AuthCommandService.java
@@ -1,9 +1,13 @@
 package com.winner.client.userservice.user.application.service;
 
+import com.winner.client.userservice.user.application.command.LoginCommand;
 import com.winner.client.userservice.user.application.command.SignupCommand;
+import com.winner.client.userservice.user.application.result.LoginResult;
 import com.winner.client.userservice.user.application.result.SignupResult;
 
 public interface AuthCommandService {
 
   SignupResult signup(SignupCommand command);
+
+  LoginResult login(LoginCommand command);
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/service/impl/AuthCommandServiceImpl.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/service/impl/AuthCommandServiceImpl.java
@@ -1,8 +1,11 @@
 package com.winner.client.userservice.user.application.service.impl;
 
+import com.winner.client.global.config.jwt.JwtTokenProvider;
 import com.winner.client.global.exception.BusinessException;
 import com.winner.client.userservice.common.exception.UserErrorCode;
+import com.winner.client.userservice.user.application.command.LoginCommand;
 import com.winner.client.userservice.user.application.command.SignupCommand;
+import com.winner.client.userservice.user.application.result.LoginResult;
 import com.winner.client.userservice.user.application.result.SignupResult;
 import com.winner.client.userservice.user.application.service.AuthCommandService;
 import com.winner.client.userservice.user.domain.entity.User;
@@ -22,10 +25,11 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
   private final PasswordEncoder passwordEncoder;
   private final UserRepository userRepository;
+  private final JwtTokenProvider jwtTokenProvider;
 
   @Transactional
   public SignupResult signup(SignupCommand command) {
-    if (userRepository.findByUsernameAndDeletedAtNull(command.username())) {
+    if (userRepository.existsByUsernameAndDeletedAtNull(command.username())) {
       throw new BusinessException(UserErrorCode.DUPLICATE_USERNAME);
     }
     User user = User.create(
@@ -40,5 +44,29 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         )
     );
     return SignupResult.from(userRepository.save(user));
+  }
+
+  public LoginResult login(LoginCommand command) {
+    User user = userRepository.findByUsernameAndDeletedAtNull(command.username())
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    if (!user.isCorrectPassword(command.password(), passwordEncoder)) {
+      throw new BusinessException(UserErrorCode.LOGIN_FAILED);
+    }
+    System.out.println(user);
+    System.out.println(user.getApprovalStatus().name());
+
+    if (!user.isApprove()) {
+      throw new BusinessException(UserErrorCode.USER_NOT_APPROVED);
+    }
+
+    String accessToken = jwtTokenProvider.createAccessToken(
+        user.getId(),
+        user.getRoleName(),
+        user.getReferenceId(),
+        user.isActive());
+
+    String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+    return LoginResult.from(user.getId(), accessToken, refreshToken);
   }
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/domain/repository/UserRepository.java
@@ -1,10 +1,13 @@
 package com.winner.client.userservice.user.domain.repository;
 
 import com.winner.client.userservice.user.domain.entity.User;
+import java.util.Optional;
 
 public interface UserRepository {
 
   User save(User user);
 
-  boolean findByUsernameAndDeletedAtNull(String username);
+  boolean existsByUsernameAndDeletedAtNull(String username);
+
+  Optional<User> findByUsernameAndDeletedAtNull(String username);
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/AuthController.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/AuthController.java
@@ -3,7 +3,9 @@ package com.winner.client.userservice.user.presentation;
 import com.winner.client.global.response.ApiResponse;
 import com.winner.client.global.response.CommonSuccessCode;
 import com.winner.client.userservice.user.application.service.AuthCommandService;
+import com.winner.client.userservice.user.presentation.request.LoginRequest;
 import com.winner.client.userservice.user.presentation.request.SignupRequest;
+import com.winner.client.userservice.user.presentation.response.LoginResponse;
 import com.winner.client.userservice.user.presentation.response.SignupResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,23 @@ public class AuthController {
                 CommonSuccessCode.CREATED,
                 SignupResponse.from(
                     authCommandService.signup(SignupRequest.toCommand(signupRequest))
+                )
+            )
+        );
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<ApiResponse<LoginResponse>> login
+      (@Valid @RequestBody LoginRequest loginRequest) {
+    return ResponseEntity
+        .status(
+            CommonSuccessCode.OK.getStatus()
+        )
+        .body(
+            ApiResponse.success(
+                CommonSuccessCode.OK,
+                LoginResponse.from(
+                    authCommandService.login(LoginRequest.toCommand(loginRequest))
                 )
             )
         );

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/request/LoginRequest.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/request/LoginRequest.java
@@ -1,0 +1,18 @@
+package com.winner.client.userservice.user.presentation.request;
+
+import com.winner.client.userservice.user.application.command.LoginCommand;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
+
+public record LoginRequest(
+    @Length(min = 4, max = 10)
+    @NotBlank(message = "아이디는 필수입니다.")
+    String username,
+    @Length(min = 8, max = 15)
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    String password) {
+
+  public static LoginCommand toCommand(LoginRequest request) {
+    return new LoginCommand(request.username, request.password);
+  }
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/response/LoginResponse.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/response/LoginResponse.java
@@ -1,0 +1,17 @@
+package com.winner.client.userservice.user.presentation.response;
+
+import com.winner.client.userservice.user.application.result.LoginResult;
+import java.util.UUID;
+
+public record LoginResponse(
+    UUID userId,
+    String accessToken,
+    String refreshToken
+) {
+
+  public static LoginResponse from(LoginResult result) {
+    return new LoginResponse(
+        result.userId(), result.accessToken(), result.refreshToken()
+    );
+  }
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #77

### 📌 작업 내용
- 로그인 수행 

### ✨ 변경 사항
- 유저 있는 지 확인
- 비밀번호 맞는 지 확인
- 토큰 생성

### 📝 리뷰 포인트 (선택)
- 중복 로그인 방지를 하지 않았는데 해야 될까라는 의문점 ( 왜냐면 여러 pc 에서 조회할 수도 있지 않을까? )
- queryDsl 라이브러리 빼는 게 다른 도메인에서도 잘 작동될까라는 테스트는 아직 안 해봤음

### 🧠 기타 참고 사항