### PR TITLE
[feat] Hub 도메인에 글로벌 예외 처리 및 ErrorCode 구조 적용

### DIFF
--- a/hub-service/src/main/java/com/winner/client/hubservice/common/exception/GlobalExceptionHandler.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.winner.client.hubservice.common.exception;
+
+import com.winner.client.global.exception.BusinessException;
+import com.winner.client.global.exception.CommonErrorCode;
+import com.winner.client.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.warn("BusinessException 발생: {}", e.getErrorCode().getMessage());
+
+        return ResponseEntity
+            .status(e.getErrorCode().getStatus())
+            .body(ApiResponse.error(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unhandled Exception: ", e);
+
+        return ResponseEntity
+            .status(CommonErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+            .body(ApiResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/common/exception/hub/HubErrorCode.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/common/exception/hub/HubErrorCode.java
@@ -1,0 +1,20 @@
+package com.winner.client.hubservice.common.exception.hub;
+
+import com.winner.client.global.code.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum HubErrorCode implements ErrorCode {
+
+    HUB_NOT_FOUND("ERROR_700", HttpStatus.NOT_FOUND, "존재하지 않는 허브입니다."),
+    DUPLICATE_HUB("ERROR_701", HttpStatus.CONFLICT, "이미 존재하는 허브입니다."),
+    INVALID_HUB_ID("ERROR_702", HttpStatus.BAD_REQUEST, "유효하지 않은 허브 ID입니다."),
+    INVALID_HUB_NAME("ERROR_703", HttpStatus.BAD_REQUEST, "허브 이름은 필수입니다.");
+
+    private final String code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/common/exception/hub/HubException.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/common/exception/hub/HubException.java
@@ -1,0 +1,12 @@
+package com.winner.client.hubservice.common.exception.hub;
+
+import com.winner.client.global.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class HubException extends BusinessException {
+
+    public HubException(HubErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
@@ -1,5 +1,7 @@
 package com.winner.client.hubservice.hub.application;
 
+import com.winner.client.hubservice.common.exception.hub.HubErrorCode;
+import com.winner.client.hubservice.common.exception.hub.HubException;
 import com.winner.client.hubservice.hub.application.dto.CreateHubCommand;
 import com.winner.client.hubservice.hub.application.dto.HubResult;
 import com.winner.client.hubservice.hub.domain.entity.Hub;
@@ -25,13 +27,17 @@ public class HubService {
             command.getLng()
         );
 
+        if (hubRepository.existsByName(command.getName())) {
+            throw new HubException(HubErrorCode.DUPLICATE_HUB);
+        }
+
         Hub hub = Hub.create(command.getName(), location);
         return hubRepository.save(hub).getId();
     }
 
     public HubResult getHub(UUID hubId) {
         Hub hub = hubRepository.findById(hubId)
-            .orElseThrow(()-> new IllegalArgumentException("허브를 찾을 수 없습니다. ID: " + hubId));
+            .orElseThrow(()-> new HubException(HubErrorCode.HUB_NOT_FOUND));
 
         return HubResult.builder()
             .id(hub.getId())

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/Hub.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/Hub.java
@@ -1,5 +1,7 @@
 package com.winner.client.hubservice.hub.domain.entity;
 
+import com.winner.client.hubservice.common.exception.hub.HubErrorCode;
+import com.winner.client.hubservice.common.exception.hub.HubException;
 import com.winner.client.hubservice.hub.domain.vo.HubLocation;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -30,7 +32,7 @@ public class Hub {
 
     private Hub(String name, HubLocation location) {
         if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("허브 이름은 null이거나 빈 문자열일 수 없습니다.");
+            throw new HubException(HubErrorCode.INVALID_HUB_NAME);
         }
         this.name = name;
         this.location = location;

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRepository.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HubRepository extends JpaRepository<Hub, UUID> {
 
+    boolean existsByName(String name);
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #102 

### 📌 작업 내용
- Hub 도메인에 ErrorCode 기반 예외 처리 구조 적용
- HubErrorCode 및 HubException 클래스 추가
- GlobalExceptionHandler를 통해 공통 예외 처리 구성
- HubService에서 IllegalArgumentException 제거 후 HubException으로 변경
- Hub 엔티티 validation 로직에 예외 처리 적용

### ✨ 변경 사항
- HubErrorCode 추가 (700번대 에러 코드 정의)
- HubException 추가 (BusinessException 상속)
- GlobalExceptionHandler 추가 (BusinessException 및 Exception 처리)
- HubRepository에 existsByName 메서드 추가
- HubService에 중복 및 조회 예외 처리 적용
- Hub 엔티티 생성 시 유효성 검증 로직 수정

### 📝 리뷰 포인트
- HubException을 별도로 분리한 구조가 적절한지
- ErrorCode 네이밍 및 범위 설정이 적절한지

### 🧠 기타 참고 사항
- 모든 도메인에서 공통적으로 사용할 수 있도록 ErrorCode 기반 예외 처리 구조를 도입하였습니다.