### PR TITLE
[feat] 배송 및 배송 경로 생성 기능 구현

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/DeliveryServiceApplication.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/DeliveryServiceApplication.java
@@ -2,8 +2,10 @@ package com.winner.client.deliveryservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class DeliveryServiceApplication {
 
 	public static void main(String[] args) {

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/delivery/DeliveryErrorCode.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/delivery/DeliveryErrorCode.java
@@ -18,7 +18,8 @@ public enum DeliveryErrorCode implements ErrorCode {
   NOT_ALL_ROUTES_COMPLETED("ERROR_508", HttpStatus.BAD_REQUEST, "하위 배송 경로가 모두 완료되지 않아 배송을 완료할 수 없습니다."),
   INVALID_DELIVERY_STATUS_TRANSITION("ERROR_509", HttpStatus.BAD_REQUEST, "현재 상태에서 해당 단계로 변경할 수 없습니다."),
   CANNOT_CANCEL_ROUTE("ERROR_510", HttpStatus.BAD_REQUEST, "이미 배송이 진행 중이거나 완료된 경로는 취소할 수 없습니다."),
-  CANNOT_CANCEL_DELIVERY("ERROR_511", HttpStatus.BAD_REQUEST, "이미 진행 중이거나 완료된 배송은 취소할 수 없습니다.")
+  CANNOT_CANCEL_DELIVERY("ERROR_511", HttpStatus.BAD_REQUEST, "이미 진행 중이거나 완료된 배송은 취소할 수 없습니다."),
+  ALREADY_DELIVERY_ASSIGNED("ERROR_512", HttpStatus.CONFLICT, "이미 배송이 배정된 주문입니다.")
   ;
 
   private final String code;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CreateDeliveryCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CreateDeliveryCommand.java
@@ -1,0 +1,31 @@
+package com.winner.client.deliveryservice.delivery.application.dto.command;
+
+import com.winner.client.deliveryservice.delivery.domain.vo.Address;
+import com.winner.client.deliveryservice.delivery.domain.vo.HubRoute;
+import com.winner.client.deliveryservice.delivery.domain.vo.Receiver;
+import com.winner.client.deliveryservice.delivery.presentation.dto.request.CreateDeliveryRequest;
+import java.util.UUID;
+
+public record CreateDeliveryCommand(
+    UUID deliveryId,
+    UUID ordersId,
+    HubRoute hubRoute,
+    String originHubName,
+    String destinationHubName,
+    Receiver receiver,
+    Address address
+) {
+  public static CreateDeliveryCommand from(CreateDeliveryRequest request) {
+    return new CreateDeliveryCommand(
+        request.deliveryId(),
+        request.ordersId(),
+
+        new HubRoute(request.originHubId(), request.destinationHubId()),
+        request.originHubName(),
+        request.destinationHubName(),
+
+        new Receiver(request.receiverId(), request.receiver(), request.slackId()),
+        new Address(request.roadAddress(), request.detailAddress())
+    );
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CreateDeliveryCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CreateDeliveryCommand.java
@@ -7,7 +7,6 @@ import com.winner.client.deliveryservice.delivery.presentation.dto.request.Creat
 import java.util.UUID;
 
 public record CreateDeliveryCommand(
-    UUID deliveryId,
     UUID ordersId,
     HubRoute hubRoute,
     String originHubName,
@@ -17,7 +16,6 @@ public record CreateDeliveryCommand(
 ) {
   public static CreateDeliveryCommand from(CreateDeliveryRequest request) {
     return new CreateDeliveryCommand(
-        request.deliveryId(),
         request.ordersId(),
 
         new HubRoute(request.originHubId(), request.destinationHubId()),

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CreateDeliveryRouteCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CreateDeliveryRouteCommand.java
@@ -1,0 +1,34 @@
+package com.winner.client.deliveryservice.delivery.application.dto.command;
+
+import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
+import com.winner.client.deliveryservice.delivery.domain.vo.CurrentHubRoute;
+import com.winner.client.deliveryservice.delivery.domain.vo.Distance;
+import com.winner.client.deliveryservice.delivery.domain.vo.Duration;
+import java.util.List;
+
+public record CreateDeliveryRouteCommand(
+    Delivery delivery,
+    CurrentHubRoute currentHubRoute,
+    String curHubName,
+    String nextHubName,
+    int sequence,
+    Distance estimatedDistance,
+    Duration estimatedArrivalTime
+) {
+  public static List<CreateDeliveryRouteCommand> of(
+      Delivery delivery, HubRouteInfo hubRouteInfo
+  ) {
+    return hubRouteInfo.nodes().stream()
+        .map(node -> new CreateDeliveryRouteCommand(
+            delivery,
+            new CurrentHubRoute(node.fromHubId(), node.toHubId()),
+            node.fromHubName(),
+            node.toHubName(),
+            node.sequence(),
+            new Distance(node.estimatedDistance()),
+            new Duration(node.estimatedArrivalTime())
+        ))
+        .toList();
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/external/HubRouteInfo.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/external/HubRouteInfo.java
@@ -1,0 +1,38 @@
+package com.winner.client.deliveryservice.delivery.application.dto.external;
+
+import com.winner.client.deliveryservice.delivery.infrastructure.client.dto.HubRouteResponse;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public record HubRouteInfo(
+    List<Node> nodes,
+    int count
+) {
+  public static HubRouteInfo from(HubRouteResponse response) {
+    return new HubRouteInfo(
+        response.nodes().stream()
+            .map(Node::from)
+            .toList(),
+        response.count()
+    );
+  }
+
+  public record Node(
+      UUID fromHubId, String fromHubName,
+      UUID toHubId, String toHubName,
+      int sequence,
+      BigDecimal estimatedDistance,
+      int estimatedArrivalTime
+  ) {
+    public static Node from(HubRouteResponse.HubNodeInfo node) {
+      return new Node(
+          node.fromHubId(), node.fromHubName(),
+          node.toHubId(), node.toHubName(),
+          node.sequence(),
+          node.estimatedDistance(),
+          node.estimatedArrivalTime()
+      );
+    }
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/result/CreateDeliveryResult.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/result/CreateDeliveryResult.java
@@ -1,0 +1,15 @@
+package com.winner.client.deliveryservice.delivery.application.dto.result;
+
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
+import java.util.UUID;
+
+public record CreateDeliveryResult(
+    UUID deliveryId, UUID deliveryManagerId
+) {
+  public static CreateDeliveryResult from(Delivery delivery){
+    return new CreateDeliveryResult(
+        delivery.getId(),
+        delivery.getDeliveryManagerId()
+    );
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/port/HubRoutePort.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/port/HubRoutePort.java
@@ -1,0 +1,8 @@
+package com.winner.client.deliveryservice.delivery.application.port;
+
+import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
+import java.util.UUID;
+
+public interface HubRoutePort {
+  HubRouteInfo getHubRoutes(UUID fromHubId, UUID toHubId);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryCommandService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryCommandService.java
@@ -1,9 +1,12 @@
 package com.winner.client.deliveryservice.delivery.application.service;
 
+import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryCommand;
+import com.winner.client.deliveryservice.delivery.presentation.dto.request.CreateDeliveryRequest;
 import com.winner.client.deliveryservice.delivery.presentation.dto.response.DeliveryCommandResponse;
 import java.util.UUID;
 
 public interface DeliveryCommandService {
+  UUID createDelivery(CreateDeliveryCommand command);
   DeliveryCommandResponse startHubWaiting(
       UUID deliveryId, String userRole, UUID referenceId);
   DeliveryCommandResponse startHubMoving(

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryCommandService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryCommandService.java
@@ -1,12 +1,13 @@
 package com.winner.client.deliveryservice.delivery.application.service;
 
 import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.result.CreateDeliveryResult;
 import com.winner.client.deliveryservice.delivery.presentation.dto.request.CreateDeliveryRequest;
 import com.winner.client.deliveryservice.delivery.presentation.dto.response.DeliveryCommandResponse;
 import java.util.UUID;
 
 public interface DeliveryCommandService {
-  UUID createDelivery(CreateDeliveryCommand command);
+  CreateDeliveryResult createDelivery(CreateDeliveryCommand command);
   DeliveryCommandResponse startHubWaiting(
       UUID deliveryId, String userRole, UUID referenceId);
   DeliveryCommandResponse startHubMoving(

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryQueryService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryQueryService.java
@@ -1,5 +1,6 @@
 package com.winner.client.deliveryservice.delivery.application.service;
 
+import com.winner.client.deliveryservice.delivery.application.dto.query.SearchDeliveryQuery;
 import com.winner.client.deliveryservice.delivery.application.dto.result.FindDeliveryResult;
 import com.winner.client.deliveryservice.delivery.application.dto.result.FindDeliveryRouteResult;
 import com.winner.client.deliveryservice.delivery.application.dto.result.SearchDeliveryResult;
@@ -17,9 +18,7 @@ import org.springframework.data.domain.Page;
 public interface DeliveryQueryService {
   FindDeliveryResult getDeliveryDetail(UUID deliveryId);
   List<FindDeliveryRouteResult> getDeliveryRoutes(UUID deliveryId);
-  Page<SearchDeliveryResult> getDeliveryPage(
-      CommonPageRequest pageRequest, String keyword, String deliveryStatus,
-      UUID userId, String userRole, UUID referenceId);
+  Page<SearchDeliveryResult> getDeliveryPage(SearchDeliveryQuery query);
   PageResponse<DeliveryRouteInfoResponse> getDeliveryRoutePage(UUID userId, UUID userRole, UUID referenceId);
   FindDeliveryRouteResult getDeliveryRoute(UUID deliveryRouteId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryRouteCommandService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryRouteCommandService.java
@@ -1,5 +1,6 @@
 package com.winner.client.deliveryservice.delivery.application.service;
 
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
 import com.winner.client.deliveryservice.delivery.presentation.dto.request.UpdateDeliveryRequest;
 import com.winner.client.deliveryservice.delivery.presentation.dto.response.DeliveryRouteCommandResponse;
 import java.util.UUID;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryCommandServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryCommandServiceImpl.java
@@ -1,12 +1,20 @@
 package com.winner.client.deliveryservice.delivery.application.service.impl;
 
 import com.winner.client.deliveryservice.common.exception.delivery.DeliveryErrorCode;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryRouteCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
+import com.winner.client.deliveryservice.delivery.application.port.HubRoutePort;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryCommandService;
+import com.winner.client.deliveryservice.delivery.application.service.DeliveryRouteCommandService;
 import com.winner.client.deliveryservice.delivery.application.validator.DeliveryAccessValidator;
 import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
+import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRepository;
+import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
 import com.winner.client.deliveryservice.delivery.presentation.dto.response.DeliveryCommandResponse;
 import com.winner.client.global.exception.BusinessException;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,7 +26,29 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeliveryCommandServiceImpl implements DeliveryCommandService {
 
   private final DeliveryRepository deliveryRepository;
+  private final DeliveryRouteRepository deliveryRouteRepository;
+  private final HubRoutePort hubRoutePort;
   private final DeliveryAccessValidator validator;
+
+  @Override
+  public UUID createDelivery(CreateDeliveryCommand command) {
+    Delivery delivery =
+        Delivery.create(command.ordersId(), command.hubRoute(),
+            command.receiver(), command.address(), null);
+
+    HubRouteInfo hubRouteInfo = hubRoutePort.
+        getHubRoutes(delivery.getHubRoute().getOriginHubId(), delivery.getHubRoute().getDestinationHubId());
+
+    List<CreateDeliveryRouteCommand> routeCommands = CreateDeliveryRouteCommand.of(delivery, hubRouteInfo);
+    routeCommands.forEach(routeCommand -> {
+      DeliveryRoute route =
+          DeliveryRoute.create(routeCommand);
+      deliveryRouteRepository.save(route);
+    });
+
+    deliveryRepository.save(delivery);
+    return delivery.getId();
+  }
 
   @Override
   public DeliveryCommandResponse startHubWaiting(

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryCommandServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryCommandServiceImpl.java
@@ -4,9 +4,9 @@ import com.winner.client.deliveryservice.common.exception.delivery.DeliveryError
 import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryRouteCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
+import com.winner.client.deliveryservice.delivery.application.dto.result.CreateDeliveryResult;
 import com.winner.client.deliveryservice.delivery.application.port.HubRoutePort;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryCommandService;
-import com.winner.client.deliveryservice.delivery.application.service.DeliveryRouteCommandService;
 import com.winner.client.deliveryservice.delivery.application.validator.DeliveryAccessValidator;
 import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
 import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
@@ -31,7 +31,11 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
   private final DeliveryAccessValidator validator;
 
   @Override
-  public UUID createDelivery(CreateDeliveryCommand command) {
+  public CreateDeliveryResult createDelivery(CreateDeliveryCommand command) {
+    if(deliveryRepository.findByOrdersId(command.ordersId())){
+      throw new BusinessException(DeliveryErrorCode.ALREADY_DELIVERY_ASSIGNED);
+    }
+
     Delivery delivery =
         Delivery.create(command.ordersId(), command.hubRoute(),
             command.receiver(), command.address(), null);
@@ -47,7 +51,7 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
     });
 
     deliveryRepository.save(delivery);
-    return delivery.getId();
+    return CreateDeliveryResult.from(delivery);
   }
 
   @Override

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryQueryServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryQueryServiceImpl.java
@@ -49,12 +49,8 @@ public class DeliveryQueryServiceImpl implements DeliveryQueryService {
   }
 
   @Override
-  public Page<SearchDeliveryResult>  getDeliveryPage(
-      CommonPageRequest pageRequest, String keyword, String deliveryStatus,
-      UUID userId, String userRole, UUID referenceId) {
-    SearchDeliveryQuery searchQuery =
-        SearchDeliveryQuery.of(userId, userRole, referenceId, keyword, deliveryStatus, pageRequest);
-    Page<Delivery> deliveryPage = deliveryCustomRepository.getAllDeliveries(searchQuery);
+  public Page<SearchDeliveryResult>  getDeliveryPage(SearchDeliveryQuery query) {
+    Page<Delivery> deliveryPage = deliveryCustomRepository.getAllDeliveries(query);
     return deliveryPage.map(SearchDeliveryResult::from);
   }
 

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryRouteCommandServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryRouteCommandServiceImpl.java
@@ -1,13 +1,18 @@
 package com.winner.client.deliveryservice.delivery.application.service.impl;
 
 import com.winner.client.deliveryservice.common.exception.delivery.DeliveryErrorCode;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryRouteCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
+import com.winner.client.deliveryservice.delivery.application.port.HubRoutePort;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryRouteCommandService;
 import com.winner.client.deliveryservice.delivery.application.validator.DeliveryAccessValidator;
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
 import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
 import com.winner.client.deliveryservice.delivery.presentation.dto.request.UpdateDeliveryRequest;
 import com.winner.client.deliveryservice.delivery.presentation.dto.response.DeliveryRouteCommandResponse;
 import com.winner.client.global.exception.BusinessException;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/DeliveryRoute.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/DeliveryRoute.java
@@ -1,6 +1,7 @@
 package com.winner.client.deliveryservice.delivery.domain.entity;
 
 import com.winner.client.deliveryservice.common.exception.delivery.DeliveryErrorCode;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryRouteCommand;
 import com.winner.client.deliveryservice.delivery.domain.enums.DeliveryRouteStatus;
 import com.winner.client.deliveryservice.delivery.domain.vo.CurrentHubRoute;
 import com.winner.client.deliveryservice.delivery.domain.vo.Distance;
@@ -131,18 +132,26 @@ public class DeliveryRoute {
   }
 
   public DeliveryRoute(Delivery delivery, int seq, CurrentHubRoute currentHubRoute,
-      Distance estimatedDistance, Duration estimatedArrivalTime) {
+      String curHubName, String nextHubName, Distance estimatedDistance, Duration estimatedArrivalTime) {
     this.delivery = delivery;
     this.seq = seq;
     this.currentHubRoute = currentHubRoute;
+    this.curHubName = curHubName;
+    this.nextHubName = nextHubName;
     this.estimatedDistance = estimatedDistance;
     this.estimatedArrivalTime = estimatedArrivalTime;
     this.status = DeliveryRouteStatus.WAITING;
   }
 
-  public static DeliveryRoute create(Delivery delivery, int seq, CurrentHubRoute currentHubRoute,
-      Distance estimatedDistance, Duration estimatedArrivalTime){
-    validateSeq(seq);
-    return new DeliveryRoute(delivery, seq, currentHubRoute, estimatedDistance, estimatedArrivalTime);
+  public static DeliveryRoute create(CreateDeliveryRouteCommand command) {
+    return new DeliveryRoute(
+        command.delivery(),
+        command.sequence(),
+        command.currentHubRoute(),
+        command.curHubName(),
+        command.nextHubName(),
+        command.estimatedDistance(),
+        command.estimatedArrivalTime()
+    );
   }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRepository.java
@@ -9,4 +9,5 @@ public interface DeliveryRepository{
   Optional<Delivery> findByIdWithRoutes(UUID id);
   Optional<Delivery> findById(UUID id);
   void save(Delivery delivery);
+  boolean findByOrdersId(UUID ordersId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 public interface DeliveryRepository{
   Optional<Delivery> findByIdWithRoutes(UUID id);
   Optional<Delivery> findById(UUID id);
+  void save(Delivery delivery);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRouteRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRouteRepository.java
@@ -4,9 +4,9 @@ import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.stereotype.Repository;
 
 public interface DeliveryRouteRepository {
   List<DeliveryRoute> findAllByDeliveryId(UUID deliveryId);
   Optional<DeliveryRoute> findById(UUID id);
+  void save(DeliveryRoute route);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/HubClient.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/HubClient.java
@@ -1,0 +1,13 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.client;
+
+import com.winner.client.deliveryservice.delivery.infrastructure.client.dto.HubRouteResponse;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name="hub-service")
+public interface HubClient {
+  @GetMapping("/internal/v1/hub-routes")
+  HubRouteResponse getHubRoutes(@RequestParam UUID fromHubId, @RequestParam UUID toHubId);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/HubClientAdapter.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/HubClientAdapter.java
@@ -1,0 +1,21 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.client;
+
+import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
+import com.winner.client.deliveryservice.delivery.application.port.HubRoutePort;
+import com.winner.client.deliveryservice.delivery.infrastructure.client.dto.HubRouteResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HubClientAdapter implements HubRoutePort {
+
+  private final HubClient hubClient;
+
+  @Override
+  public HubRouteInfo getHubRoutes(UUID fromHubId, UUID toHubId) {
+    HubRouteResponse response = hubClient.getHubRoutes(fromHubId, toHubId);
+    return HubRouteInfo.from(response); // ← 여기서 변환
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/dto/HubRouteResponse.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/dto/HubRouteResponse.java
@@ -1,0 +1,13 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.client.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public record HubRouteResponse(List<HubNodeInfo> nodes, int count) {
+  public record HubNodeInfo(
+      UUID fromHubId, String fromHubName,
+      UUID toHubId, String toHubName,
+      int sequence, BigDecimal estimatedDistance, int estimatedArrivalTime) {
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryJpaRepository.java
@@ -22,4 +22,9 @@ public class DeliveryJpaRepository implements DeliveryRepository {
   public Optional<Delivery> findById(UUID id) {
     return deliveryJpaRepository.findById(id);
   }
+
+  @Override
+  public void save(Delivery delivery) {
+    deliveryJpaRepository.save(delivery);
+  }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryJpaRepository.java
@@ -27,4 +27,9 @@ public class DeliveryJpaRepository implements DeliveryRepository {
   public void save(Delivery delivery) {
     deliveryJpaRepository.save(delivery);
   }
+
+  @Override
+  public boolean findByOrdersId(UUID ordersId) {
+    return deliveryJpaRepository.existsByOrdersId(ordersId);
+  }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
@@ -22,4 +22,9 @@ public class DeliveryRouteJpaRepository implements DeliveryRouteRepository {
   public Optional<DeliveryRoute> findById(UUID id) {
     return routeJpaRepository.findById(id);
   }
+
+  @Override
+  public void save(DeliveryRoute route) {
+    routeJpaRepository.save(route);
+  }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRepository.java
@@ -10,4 +10,5 @@ import org.springframework.data.repository.query.Param;
 public interface SpringDataDeliveryRepository extends JpaRepository<Delivery, UUID> {
   @Query("SELECT d FROM Delivery d JOIN FETCH d.routes WHERE d.id = :id")
   Optional<Delivery> findByIdWithRoutes(@Param("id") UUID id);
+  boolean existsByOrdersId(UUID ordersId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/DeliveryController.java
@@ -1,6 +1,6 @@
 package com.winner.client.deliveryservice.delivery.presentation.controller;
 
-import com.winner.client.deliveryservice.delivery.application.dto.result.FindDeliveryResult;
+import com.winner.client.deliveryservice.delivery.application.dto.query.SearchDeliveryQuery;
 import com.winner.client.deliveryservice.delivery.application.dto.result.SearchDeliveryResult;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryCommandService;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryQueryService;
@@ -19,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -41,8 +40,10 @@ public class DeliveryController {
       @RequestHeader("X-User-Role") String userRole,
       @RequestHeader("X-Reference-Id") UUID referenceId
   ) {
-    Page<SearchDeliveryResult> resultPage =
-        deliveryQueryService.getDeliveryPage(pageRequest, keyword, deliveryStatus, userId, userRole, referenceId);
+    SearchDeliveryQuery query =
+        SearchDeliveryQuery.of(userId, userRole, referenceId, keyword, deliveryStatus, pageRequest);
+
+    Page<SearchDeliveryResult> resultPage = deliveryQueryService.getDeliveryPage(query);
     Page<DeliveryInfoResponse> infoPage = resultPage.map(DeliveryInfoResponse::from);
     PageResponse<DeliveryInfoResponse> response = PageResponse.of(infoPage);
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/InternalDeliveryController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/InternalDeliveryController.java
@@ -1,0 +1,24 @@
+package com.winner.client.deliveryservice.delivery.presentation.controller;
+
+import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryCommand;
+import com.winner.client.deliveryservice.delivery.application.service.DeliveryCommandService;
+import com.winner.client.deliveryservice.delivery.presentation.dto.request.CreateDeliveryRequest;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/delivery")
+public class InternalDeliveryController {
+
+  private final DeliveryCommandService deliveryCommandService;
+
+  @PostMapping
+  public UUID createDelivery(CreateDeliveryRequest request) {
+    CreateDeliveryCommand command = CreateDeliveryCommand.from(request);
+    return deliveryCommandService.createDelivery(command);
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/InternalDeliveryController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/InternalDeliveryController.java
@@ -1,9 +1,10 @@
 package com.winner.client.deliveryservice.delivery.presentation.controller;
 
 import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.result.CreateDeliveryResult;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryCommandService;
 import com.winner.client.deliveryservice.delivery.presentation.dto.request.CreateDeliveryRequest;
-import java.util.UUID;
+import com.winner.client.deliveryservice.delivery.presentation.dto.response.CreateDeliveryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,8 +18,9 @@ public class InternalDeliveryController {
   private final DeliveryCommandService deliveryCommandService;
 
   @PostMapping
-  public UUID createDelivery(CreateDeliveryRequest request) {
+  public CreateDeliveryResponse createDelivery(CreateDeliveryRequest request) {
     CreateDeliveryCommand command = CreateDeliveryCommand.from(request);
-    return deliveryCommandService.createDelivery(command);
+    CreateDeliveryResult result = deliveryCommandService.createDelivery(command);
+    return CreateDeliveryResponse.from(result);
   }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/dto/request/CreateDeliveryRequest.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/dto/request/CreateDeliveryRequest.java
@@ -1,0 +1,17 @@
+package com.winner.client.deliveryservice.delivery.presentation.dto.request;
+
+import java.util.UUID;
+
+public record CreateDeliveryRequest(
+    UUID deliveryId,
+    UUID ordersId,
+    UUID originHubId,
+    UUID destinationHubId,
+    String originHubName,
+    String destinationHubName,
+    UUID receiverId,
+    String receiver,
+    String slackId,
+    String roadAddress,
+    String detailAddress
+) {}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/dto/request/CreateDeliveryRequest.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/dto/request/CreateDeliveryRequest.java
@@ -3,7 +3,6 @@ package com.winner.client.deliveryservice.delivery.presentation.dto.request;
 import java.util.UUID;
 
 public record CreateDeliveryRequest(
-    UUID deliveryId,
     UUID ordersId,
     UUID originHubId,
     UUID destinationHubId,

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/dto/response/CreateDeliveryResponse.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/dto/response/CreateDeliveryResponse.java
@@ -1,0 +1,13 @@
+package com.winner.client.deliveryservice.delivery.presentation.dto.response;
+
+import com.winner.client.deliveryservice.delivery.application.dto.result.CreateDeliveryResult;
+import java.util.UUID;
+
+public record CreateDeliveryResponse(UUID deliveryId, UUID deliveriesId) {
+  public static CreateDeliveryResponse from(CreateDeliveryResult result) {
+    return new CreateDeliveryResponse(
+        result.deliveryId(),
+        result.deliveryManagerId()
+    );
+  }
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #90 

### 📌 작업 내용
- 배송 생성 및 배송 경로 생성 기능을 구현하였습니다.
- FeignClient를 설정하여 허브 서비스 간 경로 조회가 가능하도록 연동하였습니다.
- 배송 생성 시 허브 간 이동 경로를 기반으로 배송 경로를 함께 생성하도록 로직을 구성하였습니다.

### ✨ 변경 사항
- 배송 생성 시 경로 정보까지 함께 처리할 수 있도록 기능 확장
- 서비스 간 통신(FeignClient)을 도입하여 허브 경로 조회를 자동화
- 배송 및 경로 생성 로직을 통합하여 비즈니스 흐름의 일관성 강화

### 📝 리뷰 포인트 (선택)
- FeignClient가 DDD 도메인에 적절하게 배치되었는지
- 생성 메소드 코드가 적절한지

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)