### PR TITLE
[feat]: 배송담당자 배정 로직 구현 (이벤트 기반, DIP적용)

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignFailEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignFailEvent.java
@@ -1,0 +1,11 @@
+package com.winner.client.deliveryservice.common.event;
+
+public record AssignFailEvent(
+	String message
+) {
+
+	public static AssignFailEvent from(String message) {
+		return new AssignFailEvent(message);
+	}
+
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignSuccessEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignSuccessEvent.java
@@ -1,0 +1,12 @@
+package com.winner.client.deliveryservice.common.event;
+
+import java.util.UUID;
+
+public record AssignSuccessEvent (
+	UUID deliveryId,
+	UUID orderId
+) {
+	public static AssignSuccessEvent of(UUID deliveryId, UUID orderId) {
+		return new AssignSuccessEvent(deliveryId, orderId);
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/DeliveryCreateEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/DeliveryCreateEvent.java
@@ -1,5 +1,6 @@
 package com.winner.client.deliveryservice.common.event;
 
+import com.winner.client.deliveryservice.deliverymanagerhub.application.commnad.AssignEventCommand;
 import java.util.UUID;
 
 public record DeliveryCreateEvent(
@@ -7,4 +8,7 @@ public record DeliveryCreateEvent(
 	UUID orderId
 ) {
 
+	public AssignEventCommand toCommand() {
+		return new AssignEventCommand(this.deliveryId, this.orderId);
+	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/hub/DeliveryManagerHubErrorCode.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/hub/DeliveryManagerHubErrorCode.java
@@ -15,7 +15,9 @@ public enum DeliveryManagerHubErrorCode implements ErrorCode {
 	NOT_FOUND_HUB_DELIVERY_MANAGER("ERROR_653", HttpStatus.NOT_FOUND,
 		"존재하지 않는 허브배송담당자 입니다."),
 	DELIVERY_MANAGER_IN_PROGRESS("ERROR_654", HttpStatus.BAD_REQUEST,
-		"업무 진행 중엔 탈퇴가 불가능 합니다.")
+		"업무 진행 중엔 탈퇴가 불가능 합니다."),
+	NOT_FOUND_AVAILABLE_HUB_DELIVERY_MANAGERS("ERROR_655", HttpStatus.NOT_FOUND,
+		"배정 가능한 허브 배송담당자를 찾을 수 없습니다."),
 	;
 
 	private final String code;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubWriteService.java
@@ -1,24 +1,31 @@
 package com.winner.client.deliveryservice.deliverymanagerhub.application;
 
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode.ALREADY_REGISTERED_HUB_DELIVERY_MANAGER;
+import static com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode.NOT_FOUND_AVAILABLE_HUB_DELIVERY_MANAGERS;
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.hub.DeliveryManagerHubErrorCode.NOT_FOUND_HUB_DELIVERY_MANAGER;
 
+import com.winner.client.deliveryservice.deliverymanagerhub.application.commnad.AssignEventCommand;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.commnad.DeliveryManagerHubRegistrationCommand;
+import com.winner.client.deliveryservice.deliverymanagerhub.application.message.DeliveryDeliveryManagerHubUsecase;
+import com.winner.client.deliveryservice.deliverymanagerhub.application.message.DeliveryMessagePort;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.result.DeliveryManagerHubInfoResult;
 import com.winner.client.deliveryservice.deliverymanagerhub.domain.entity.DeliveryManagerHub;
 import com.winner.client.deliveryservice.deliverymanagerhub.domain.repository.DeliveryManagerHubRepository;
 import com.winner.client.global.exception.BusinessException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class DeliveryManagerHubWriteService {
+@Slf4j
+public class DeliveryManagerHubWriteService implements DeliveryDeliveryManagerHubUsecase {
 
 	private final DeliveryManagerHubRepository repository;
+	private final DeliveryMessagePort deliveryMessagePort;
 
 	public DeliveryManagerHubInfoResult registration(
 		DeliveryManagerHubRegistrationCommand command) {
@@ -52,5 +59,27 @@ public class DeliveryManagerHubWriteService {
 		DeliveryManagerHub deliveryManagerHub = repository.findByUserId(userId)
 			.orElseThrow(() -> new BusinessException(NOT_FOUND_HUB_DELIVERY_MANAGER));
 		deliveryManagerHub.softDelete(userId);
+	}
+
+	@Override
+	public void assignHubDeliveryManager(AssignEventCommand command) {
+		try {
+			DeliveryManagerHub manager = selectAvailableManager();
+			manager.assignDelivery(command.deliveryId());
+			log.info("AssignHubDeliveryManager: {}, deliveryId: {}"
+				, manager.getUserId(), manager.getDeliveryId());
+			deliveryMessagePort.successEventPublish(command.deliveryId(), command.orderId());
+		} catch (BusinessException e) {
+			log.warn("DeliveryManager assignment failure : {}", e.getMessage());
+			deliveryMessagePort.failEventPublish(e.getMessage());
+		}
+	}
+
+	private DeliveryManagerHub selectAvailableManager() {
+		//todo: 현재 배송 가능한 담당자중 가장 알맞은 담당자에게 배정되는 알고리즘 필요 ex. 최근 배송기록이 가장 오래된 담당자로 배정
+		return repository.findAllAvailableManagers()
+			.stream()
+			.findFirst()
+			.orElseThrow(() -> new BusinessException(NOT_FOUND_AVAILABLE_HUB_DELIVERY_MANAGERS));
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/commnad/AssignEventCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/commnad/AssignEventCommand.java
@@ -1,0 +1,10 @@
+package com.winner.client.deliveryservice.deliverymanagerhub.application.commnad;
+
+import java.util.UUID;
+
+public record AssignEventCommand (
+	UUID deliveryId,
+	UUID orderId
+) {
+
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/message/DeliveryDeliveryManagerHubUsecase.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/message/DeliveryDeliveryManagerHubUsecase.java
@@ -1,0 +1,8 @@
+package com.winner.client.deliveryservice.deliverymanagerhub.application.message;
+
+import com.winner.client.deliveryservice.deliverymanagerhub.application.commnad.AssignEventCommand;
+
+
+public interface DeliveryDeliveryManagerHubUsecase {
+	void assignHubDeliveryManager(AssignEventCommand command);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/message/DeliveryMessagePort.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/message/DeliveryMessagePort.java
@@ -1,0 +1,8 @@
+package com.winner.client.deliveryservice.deliverymanagerhub.application.message;
+
+import java.util.UUID;
+
+public interface DeliveryMessagePort {
+	void failEventPublish(String message);
+	void successEventPublish(UUID deliveryId, UUID orderId);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/domain/repository/DeliveryManagerHubRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/domain/repository/DeliveryManagerHubRepository.java
@@ -1,6 +1,7 @@
 package com.winner.client.deliveryservice.deliverymanagerhub.domain.repository;
 
 import com.winner.client.deliveryservice.deliverymanagerhub.domain.entity.DeliveryManagerHub;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +12,5 @@ public interface DeliveryManagerHubRepository {
 	Long countByDeletedByIsNull();
 	Optional<DeliveryManagerHub> findFirstByOrderByAssignmentOrderDesc();
 	Optional<DeliveryManagerHub> findByUserId(UUID userId);
+	List<DeliveryManagerHub> findAllAvailableManagers();
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/DeliveryManagerHubJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/DeliveryManagerHubJpaRepository.java
@@ -2,6 +2,7 @@ package com.winner.client.deliveryservice.deliverymanagerhub.infrastructure;
 
 import com.winner.client.deliveryservice.deliverymanagerhub.domain.entity.DeliveryManagerHub;
 import com.winner.client.deliveryservice.deliverymanagerhub.domain.repository.DeliveryManagerHubRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -36,5 +37,10 @@ public class DeliveryManagerHubJpaRepository implements DeliveryManagerHubReposi
 	@Override
 	public Optional<DeliveryManagerHub> findByUserId(UUID userId) {
 		return repository.findByUserId_ValueAndDeletedByNull(userId);
+	}
+
+	@Override
+	public List<DeliveryManagerHub> findAllAvailableManagers() {
+		return repository.findAllAvailableManagers();
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/SpringDataDeliveryManagerHubRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/SpringDataDeliveryManagerHubRepository.java
@@ -1,9 +1,11 @@
 package com.winner.client.deliveryservice.deliverymanagerhub.infrastructure;
 
 import com.winner.client.deliveryservice.deliverymanagerhub.domain.entity.DeliveryManagerHub;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SpringDataDeliveryManagerHubRepository extends JpaRepository<DeliveryManagerHub, UUID> {
 
@@ -11,4 +13,9 @@ public interface SpringDataDeliveryManagerHubRepository extends JpaRepository<De
 	Optional<DeliveryManagerHub> findFirstByOrderByAssignmentOrder_ValueDesc();
 	Long countByDeletedByIsNull();
 	Optional<DeliveryManagerHub> findByUserId_ValueAndDeletedByNull(UUID userId);
+	@Query("SELECT d FROM DeliveryManagerHub d " +
+		"WHERE d.deletedBy IS NULL " +
+		"AND d.deliveryManagerStatus = 'AVAILABLE'" +
+		"ORDER BY d.assignmentOrder.value ASC")
+	List<DeliveryManagerHub> findAllAvailableManagers();
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryManagerHubSpringEventListener.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryManagerHubSpringEventListener.java
@@ -1,0 +1,19 @@
+package com.winner.client.deliveryservice.deliverymanagerhub.infrastructure.message;
+
+import com.winner.client.deliveryservice.common.event.DeliveryCreateEvent;
+import com.winner.client.deliveryservice.deliverymanagerhub.application.message.DeliveryDeliveryManagerHubUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryManagerHubSpringEventListener {
+
+	private final DeliveryDeliveryManagerHubUsecase usecase;
+
+	@EventListener
+	public void assignDeliveryManagerHub(DeliveryCreateEvent event) {
+		usecase.assignHubDeliveryManager(event.toCommand());
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryMessagePortImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryMessagePortImpl.java
@@ -1,0 +1,26 @@
+package com.winner.client.deliveryservice.deliverymanagerhub.infrastructure.message;
+
+import com.winner.client.deliveryservice.common.event.AssignFailEvent;
+import com.winner.client.deliveryservice.common.event.AssignSuccessEvent;
+import com.winner.client.deliveryservice.deliverymanagerhub.application.message.DeliveryMessagePort;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryMessagePortImpl implements DeliveryMessagePort {
+
+	private final ApplicationEventPublisher	publisher;
+
+	@Override
+	public void failEventPublish(String message) {
+		publisher.publishEvent(AssignFailEvent.from(message));
+	}
+
+	@Override
+	public void successEventPublish(UUID deliveryId, UUID orderId) {
+		publisher.publishEvent(AssignSuccessEvent.of(deliveryId, orderId));
+	}
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #87 

### 🚀 아키텍처 및 로직 흐름 요약

**인프라가 애플리케이션을 호출하고, 애플리케이션이 결과를 다시 인프라로 던지는 구조**

#### 1. 계층별 역할 분담
- `Infrastructure`: 
  - `EventListener` (이벤트 수신, 구현체)
  - `MessagePortImpl` (결과 발행, 구현체)
- `Application`: 
  - `Usecase` (인터페이스)
  - `WriteService` (구현체)
  - `MessagePort` (인터페이스)

#### 2. 상세 데이터 흐름

1. **이벤트 수신**: `DeliveryManagerHubSpringEventListener`가 배송 생성 이벤트를 소비
2. **명령 전달**: 리스너가 `usecase.assignHubDeliveryManager()`를 호출하여 배정 명령 하달
3. **로직 실행**: `WriteService`에서 가용 담당자 조회 및 도메인 모델(Manager) 상태 변경
4. **결과 전파**: 서비스가 `DeliveryMessagePort` 인터페이스를 통해 성공/실패 여부 전달
6. **최종 발행**: `DeliveryMessagePortImpl`에서 실제 메시지(Success/Fail Event)를 시스템에 발행

> **💡 요약**: `Infrastructure(In)` -> `Application` -> `Infrastructure(Out)` 로 이어지는 깔끔한 제어 흐름을 지향했습니다. 각 컴포넌트 간의 의존성은 인터페이스를 통해 역전(DIP)되어 있습니다.

### 📌 작업 내용
- **이벤트 기반 배송 담당자 자동 배정 프로세스 구축**
  - 배송 생성 이벤트가 생성되면 eventListener가 소비합니다.
  가용 담당자를 선별하고 배정 상태를 업데이트하는 비즈니스 로직을 구현했습니다.
- **계층 간 관심사 분리 (DIP 적용)**
  - 인프라(이벤트 수신/발행)와 애플리케이션(배정 로직) 계층을 인터페이스로 분리하여 의존성을 분리했습니다.

### ✨ 주요 변경 사항
1. **배정 알고리즘**
   - `assignmentOrder` 일단 가용 담당자 중 순번이 제일 빠른사람으로 배정되도록 구현
   to-do 최적화 알고리즘 필요
2. **이벤트 모델링**
   - 배정 성공/실패 상태를 전달하기 위한 전용 이벤트 레코드(`AssignSuccessEvent`, `AssignFailEvent`) 생성
3. **유스케이스 추상화**
   - `DeliveryDeliveryManagerHubUsecase`를 통해 배정 서비스의 명세를 정의하고 외부(인프라)에서의 호출 흐름 캡슐화
4. **메세지 포트 추상화**
   - `DeliveryMessagePort`를 통해 메세지 발행의 명세를 정의하고 외부(인프라)에서의 호출 흐름 캡슐화

### 📝 리뷰 포인트