### PR TITLE
[Refactor] 인증 필터 (게이트웨이, security) 리팩토링 및 테스트 완료

### DIFF
--- a/gateway/src/main/java/com/winner/client/gateway/exception/GatewayErrorCode.java
+++ b/gateway/src/main/java/com/winner/client/gateway/exception/GatewayErrorCode.java
@@ -8,9 +8,16 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum GatewayErrorCode implements ErrorCode {
-  INVALID_ROLE("ERROR_400", HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-  ROUTE_NOT_FOUND("ERROR_401", HttpStatus.NOT_FOUND, "요청 경로를 찾을 수 없습니다."),
-  INTERNAL_ERROR("ERROR-402", HttpStatus.INTERNAL_SERVER_ERROR, "게이트웨이 오류");
+  UNAUTHORIZED("ERROR_401", HttpStatus.UNAUTHORIZED, "인증 정보가 유효하지 않습니다."),
+  INVALID_ROLE("ERROR_402", HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+  ROUTE_NOT_FOUND("ERROR_404", HttpStatus.NOT_FOUND, "요청 경로를 찾을 수 없습니다."),
+  METHOD_NOT_ALLOWED("ERROR_405", HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 HTTP 메서드입니다."),
+
+  SERVICE_UNAVAILABLE("ERROR_403", HttpStatus.SERVICE_UNAVAILABLE, "연결된 서비스를 찾을 수 없거나 점검 중입니다."),
+  GATEWAY_TIMEOUT("ERROR_406", HttpStatus.GATEWAY_TIMEOUT, "서비스 응답 시간이 초과되었습니다."),
+
+  INTERNAL_ERROR("ERROR_407", HttpStatus.INTERNAL_SERVER_ERROR, "게이트웨이 내부 오류가 발생했습니다.");
   private final String code;
   private final HttpStatus status;
   private final String message;

--- a/gateway/src/main/java/com/winner/client/gateway/exception/GlobalErrorExceptionHandler.java
+++ b/gateway/src/main/java/com/winner/client/gateway/exception/GlobalErrorExceptionHandler.java
@@ -29,15 +29,28 @@ public class GlobalErrorExceptionHandler implements ErrorWebExceptionHandler {
     }
 
     ErrorCode errorCode = GatewayErrorCode.INTERNAL_ERROR;
-
     if (ex instanceof BusinessException ce) {
       errorCode = ce.getErrorCode();
+    } else if (ex instanceof org.springframework.cloud.gateway.support.NotFoundException) {
+      errorCode = GatewayErrorCode.SERVICE_UNAVAILABLE;
+    } else if (ex instanceof org.springframework.web.server.ResponseStatusException rse) {
+      if (rse.getStatusCode() == org.springframework.http.HttpStatus.NOT_FOUND) {
+        errorCode = GatewayErrorCode.ROUTE_NOT_FOUND;
+      }
+    } else if (ex.getCause() instanceof java.net.ConnectException) {
+      errorCode = GatewayErrorCode.GATEWAY_TIMEOUT;
     }
+    exchange.getResponse().setStatusCode(errorCode.getStatus());
+
+    exchange.getResponse().getHeaders()
+        .setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
 
     ApiResponse<Void> errorResponse = ApiResponse.error(errorCode);
+
     try {
       byte[] bytes = objectMapper.writeValueAsBytes(errorResponse);
       DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(bytes);
+
       return exchange.getResponse().writeWith(Mono.just(buffer));
     } catch (JsonProcessingException e) {
       return exchange.getResponse().setComplete();

--- a/gateway/src/main/java/com/winner/client/gateway/filter/AllowedFilter.java
+++ b/gateway/src/main/java/com/winner/client/gateway/filter/AllowedFilter.java
@@ -6,12 +6,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 @RequiredArgsConstructor
+@Component
 public class AllowedFilter implements GlobalFilter, Ordered {
 
   private final AuthProperties authProperties;
@@ -24,7 +26,10 @@ public class AllowedFilter implements GlobalFilter, Ordered {
         .anyMatch(p -> pathMatcher.match(p.trim(), path));
 
     if (isWhiteList) {
-      return Mono.empty();
+      ServerWebExchange mutatedExchange = exchange.mutate()
+          .request(builder -> builder.header("X-Auth-Skip", "true"))
+          .build();
+      return chain.filter(mutatedExchange);
     }
     return chain.filter(exchange);
   }

--- a/gateway/src/main/java/com/winner/client/gateway/filter/GlobalLoggingFilter.java
+++ b/gateway/src/main/java/com/winner/client/gateway/filter/GlobalLoggingFilter.java
@@ -1,0 +1,29 @@
+package com.winner.client.gateway.filter;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class GlobalLoggingFilter implements GlobalFilter, Ordered {
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+    String path = exchange.getRequest().getURI().getPath();
+    log.info("Gateway 요청 : {}", path);
+    return chain.filter(exchange);
+  }
+
+  @Override
+  public int getOrder() {
+    return -1;
+  }
+}

--- a/gateway/src/main/java/com/winner/client/gateway/filter/JwtAuthenticationFilter.java
+++ b/gateway/src/main/java/com/winner/client/gateway/filter/JwtAuthenticationFilter.java
@@ -1,11 +1,10 @@
 package com.winner.client.gateway.filter;
 
+import com.winner.client.gateway.exception.GatewayErrorCode;
 import com.winner.client.global.config.jwt.JwtTokenProvider;
 import com.winner.client.global.exception.BusinessException;
-import com.winner.client.global.exception.CommonErrorCode;
 import com.winner.client.global.exception.JwtTokenErrorCode;
 import io.jsonwebtoken.Claims;
-import jakarta.ws.rs.core.HttpHeaders;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +12,7 @@ import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
@@ -27,17 +27,39 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
   @Override
   public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+    String path = exchange.getRequest().getPath().toString();
+    log.info("[JWT 필터] 요청 시작 - Path: {}", path);
+
+    String skipAuth = exchange.getRequest().getHeaders().getFirst("X-Auth-Skip");
+    if ("true".equalsIgnoreCase(skipAuth)) {
+      return chain.filter(exchange);
+    }
+
     String authHeader = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
     String token = extractToken(authHeader);
+
     if (token == null) {
-      return Mono.error(new BusinessException(CommonErrorCode.UNAUTHORIZED));
+      return Mono.error(new BusinessException(GatewayErrorCode.UNAUTHORIZED));
     }
-    if (isValidToken(token)) {
-      return Mono.error(new BusinessException(JwtTokenErrorCode.TOKEN_BLACKLISTED));
+
+    try {
+      jwtTokenProvider.validateToken(token);
+    } catch (Exception e) {
+      return Mono.error(new BusinessException(JwtTokenErrorCode.INVALID_TOKEN));
     }
-    exchange = getExchangeWithToken(exchange, token).
-        orElseThrow(() -> new BusinessException(JwtTokenErrorCode.UNSUPPORTED_TOKEN));
-    return chain.filter(exchange);
+
+    return redisTemplate.hasKey("logout:" + token)
+        .flatMap(isBlacklisted -> {
+          if (Boolean.TRUE.equals(isBlacklisted)) {
+            return Mono.error(new BusinessException(JwtTokenErrorCode.TOKEN_BLACKLISTED));
+          }
+
+          return getExchangeWithToken(exchange, token)
+              .map(chain::filter)
+              .orElseGet(() -> {
+                return Mono.error(new BusinessException(JwtTokenErrorCode.UNSUPPORTED_TOKEN));
+              });
+        });
   }
 
   private String extractToken(String authHeader) {
@@ -45,11 +67,6 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
       return null;
     }
     return authHeader.substring(7);
-  }
-
-  private boolean isValidToken(String token) {
-    jwtTokenProvider.validateToken(token);
-    return !Boolean.TRUE.equals(redisTemplate.hasKey("logout:" + token).block());
   }
 
   private Optional<ServerWebExchange> getExchangeWithToken(ServerWebExchange exchange,
@@ -60,7 +77,8 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
       String userId = claims.getSubject();
       String userRole = claims.get("role", String.class);
       String userStatus = String.valueOf(claims.get("userStatus"));
-      String referenceId = String.valueOf(claims.get("referenceId"));
+      String referenceId =
+          claims.get("referenceId") != null ? String.valueOf(claims.get("referenceId")) : "";
 
       return Optional.of(exchange.mutate()
           .request(builder -> builder
@@ -74,10 +92,8 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
     }
   }
 
-
   @Override
   public int getOrder() {
     return 1;
   }
-
 }

--- a/gateway/src/main/java/com/winner/client/gateway/filter/UserValidatorFilter.java
+++ b/gateway/src/main/java/com/winner/client/gateway/filter/UserValidatorFilter.java
@@ -16,7 +16,7 @@ import reactor.core.publisher.Mono;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class UserStatusRoutingFilter implements GlobalFilter, Ordered {
+public class UserValidatorFilter implements GlobalFilter, Ordered {
 
   private final AuthProperties authProperties;
   private final AntPathMatcher pathMatcher = new AntPathMatcher();
@@ -24,19 +24,43 @@ public class UserStatusRoutingFilter implements GlobalFilter, Ordered {
   @Override
   public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
     String path = exchange.getRequest().getURI().getPath();
+    log.info("[권한 필터] 검증 시작 - Path: {}", path);
 
+    String skipAuth = exchange.getRequest().getHeaders().getFirst("X-Auth-Skip");
+    if ("true".equalsIgnoreCase(skipAuth)) {
+      return chain.filter(exchange);
+    }
+
+    String userRole = exchange.getRequest().getHeaders().getFirst("X-User-Role");
     String statusHeader = exchange.getRequest().getHeaders().getFirst("X-User-Status");
 
+    try {
+      checkAccessControl(path, userRole);
+    } catch (BusinessException e) {
+      return Mono.error(e);
+    }
+
     if ("false".equalsIgnoreCase(statusHeader)) {
-      boolean isAllowed = authProperties.getStatusAllowList().stream()
+      boolean isStatusAllowed = authProperties.getStatusAllowList().stream()
           .anyMatch(p -> pathMatcher.match(p.trim(), path));
 
-      if (!isAllowed) {
-        return Mono.error(new BusinessException(GatewayErrorCode.INTERNAL_ERROR));
+      if (!isStatusAllowed) {
+        return Mono.error(new BusinessException(GatewayErrorCode.INVALID_ROLE));
       }
     }
 
     return chain.filter(exchange);
+  }
+
+  private void checkAccessControl(String path, String userRole) {
+    authProperties.getAccessControl().stream()
+        .filter(ac -> pathMatcher.match(ac.path(), path))
+        .findFirst()
+        .ifPresent(ac -> {
+          if (ac.roles() != null && !ac.roles().contains(userRole)) {
+            throw new BusinessException(GatewayErrorCode.INVALID_ROLE);
+          }
+        });
   }
 
   @Override

--- a/global/src/main/java/com/winner/client/global/config/SecurityConfig.java
+++ b/global/src/main/java/com/winner/client/global/config/SecurityConfig.java
@@ -2,17 +2,17 @@ package com.winner.client.global.config;
 
 import com.winner.client.global.security.FilterExceptionHandleFilter;
 import com.winner.client.global.security.PreAuthenticatedHeaderFilter;
-import com.winner.client.global.variable.AuthProperties;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -21,33 +21,34 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@EnableConfigurationProperties(AuthProperties.class)
 @ConditionalOnWebApplication(type = Type.SERVLET)
 public class SecurityConfig {
 
   private final PreAuthenticatedHeaderFilter preAuthenticatedHeaderFilter;
   private final FilterExceptionHandleFilter filterExceptionHandleFilter;
-  private final AuthProperties authProperties;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-
-    String[] whiteList = (authProperties.getWhiteList() != null)
-        ? authProperties.getWhiteList().toArray(new String[0])
-        : new String[0];
-
     return http
         .csrf(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
-        .sessionManagement(
-            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .authorizeHttpRequests(auth -> auth
-            .requestMatchers(whiteList).permitAll()
-            .anyRequest().authenticated()
-        )
+        .sessionManagement(session ->
+            session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(this::configureAuthorization)
         .addFilterBefore(preAuthenticatedHeaderFilter, UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(filterExceptionHandleFilter, preAuthenticatedHeaderFilter.getClass())
         .build();
+  }
+
+  private void configureAuthorization(AuthorizeHttpRequestsConfigurer
+      <HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth) {
+    auth
+        .requestMatchers(this::isSkipAuth).permitAll()
+        .anyRequest().authenticated();
+  }
+
+  private boolean isSkipAuth(HttpServletRequest request) {
+    return "true".equalsIgnoreCase(request.getHeader("X-Auth-Skip"));
   }
 }

--- a/global/src/main/java/com/winner/client/global/security/PreAuthenticatedHeaderFilter.java
+++ b/global/src/main/java/com/winner/client/global/security/PreAuthenticatedHeaderFilter.java
@@ -21,6 +21,19 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class PreAuthenticatedHeaderFilter extends OncePerRequestFilter {
 
+  private static UsernamePasswordAuthenticationToken getUsernamePasswordAuthenticationToken(
+      UUID userId, String userRole, UUID referenceId) {
+    CustomUserPrincipal customUserPrincipal =
+        new CustomUserPrincipal(userId, userRole, referenceId);
+
+    List<SimpleGrantedAuthority> authorities = Collections.emptyList();
+    if (userRole != null && !userRole.isEmpty()) {
+      String roleWithPrefix = "ROLE_" + userRole;
+      authorities = Collections.singletonList(new SimpleGrantedAuthority(roleWithPrefix));
+    }
+    return new UsernamePasswordAuthenticationToken(customUserPrincipal, null, authorities);
+  }
+
   @Override
   protected void doFilterInternal(HttpServletRequest request,
       HttpServletResponse response,
@@ -28,7 +41,14 @@ public class PreAuthenticatedHeaderFilter extends OncePerRequestFilter {
 
     String userIdStr = request.getHeader("X-User-Id");
     String userRole = request.getHeader("X-User-Role");
-    Object referenceIdObj = request.getHeader("X-User-ReferenceId");
+    String referenceIdStr = request.getHeader("X-User-ReferenceId");
+    String skipAuth = request.getHeader("X-Auth-Skip");
+
+    log.info("[Security 필터] 요청 감지 - Path: {}", request);
+    if ("true".equalsIgnoreCase(skipAuth)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
 
     if (userIdStr == null || userIdStr.isEmpty()) {
       throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
@@ -36,24 +56,18 @@ public class PreAuthenticatedHeaderFilter extends OncePerRequestFilter {
 
     try {
       UUID userId = UUID.fromString(userIdStr);
-      UUID referenceId;
+      UUID referenceId = null;
 
-      try {
-        referenceId = UUID.fromString(referenceIdObj.toString());
-      } catch (IllegalArgumentException e) {
-        referenceId = null;
+      if (referenceIdStr != null && !referenceIdStr.isEmpty() && !"null".equals(referenceIdStr)) {
+        try {
+          referenceId = UUID.fromString(referenceIdStr);
+        } catch (IllegalArgumentException ignored) {
+        }
       }
-      CustomUserPrincipal customUserPrincipal =
-          new CustomUserPrincipal(userId, userRole, referenceId);
-
-      List<SimpleGrantedAuthority> authorities = Collections.emptyList();
-      if (userRole != null && !userRole.isEmpty()) {
-        authorities = Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + userRole));
-      }
-      UsernamePasswordAuthenticationToken authentication =
-          new UsernamePasswordAuthenticationToken(customUserPrincipal, null, authorities);
+      UsernamePasswordAuthenticationToken authentication = getUsernamePasswordAuthenticationToken(
+          userId, userRole, referenceId);
       SecurityContextHolder.getContext().setAuthentication(authentication);
-    } catch (IllegalArgumentException e) {
+    } catch (Exception e) {
       throw new BusinessException(CommonErrorCode.UNAUTHORIZED);
     }
     filterChain.doFilter(request, response);


### PR DESCRIPTION
### 📎 관련 이슈
- close #131

### 📌 작업 내용
- **Gateway 비동기 최적화**: Blocking 코드(`.block()`) 제거 및 `flatMap` 전환으로 성능 저하 및 401 에러 해결
- **인증 흐름 개선**: 화이트리스트 및 서비스 간 통신 시 `X-Auth-Skip` 처리 로직 수정

### ✨ 주요 변경 사항

#### 1. API Gateway
- **JwtAuthenticationFilter**: Redis 블랙리스트 조회를 비동기로 수정
- **UserValidatorFilter**: 필터명 변경 및 권한/상태 검증 로직 보완
- **GlobalLoggingFilter**: 모든 요청에 대한 경로 로깅 추가 (나중에 상세 로직 추가 예정)
- **AllowedFilter**: 화이트리스트 탐색 시 인증 스킵 헤더 주입

#### 2. Global Security
- **PreAuthenticatedHeaderFilter**: Gateway 전달 헤더를 SecurityContext에 등록하는 로직 보완
- **Error Handling**: Gateway 전용 에러 코드(`GatewayErrorCode`) 세분화 및 공통 예외 처리기 적용

#### 3. 테스트
- 테스트로 userService 및 productService 테스트 완료

### 📝 리뷰 포인트
- 각 서비스에서 인증이 잘 되는지 확인해보면 좋을듯 합니다.
### 🧠 참고 사항
- [인증정보 주입받기](https://www.notion.so/teamsparta/3212dc3ef51481029251ff2023f63fcb?v=3212dc3ef514816f83f0000ccd11f484&p=3382dc3ef51480b087c9dd7912bac5c3&pm=s)