### PR TITLE
[refactor]: 이벤트 발행 메서드 통합

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubWriteService.java
@@ -6,6 +6,7 @@ import static com.winner.client.deliveryservice.common.exception.deliverymanager
 
 import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.commnad.AssignEventCommand;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.commnad.DeliveryManagerHubRegistrationCommand;
+import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.result.DeliveryAssignResult;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.message.DeliveryDeliveryManagerHubUsecase;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.message.DeliveryMessagePort;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.result.DeliveryManagerHubInfoResult;
@@ -66,12 +67,10 @@ public class DeliveryManagerHubWriteService implements DeliveryDeliveryManagerHu
 		try {
 			DeliveryManagerHub manager = selectAvailableManager();
 			manager.assignDelivery(command.deliveryId());
-			log.info("AssignHubDeliveryManager: {}, deliveryId: {}"
-				, manager.getUserId(), manager.getDeliveryId());
-			deliveryMessagePort.successEventPublish(command.deliveryId(), command.orderId());
+			deliveryMessagePort.assignEventPublish(DeliveryAssignResult.success(command));
 		} catch (BusinessException e) {
 			log.warn("DeliveryManager assignment failure : {}", e.getMessage());
-			deliveryMessagePort.failEventPublish(e.getMessage());
+			deliveryMessagePort.assignEventPublish(DeliveryAssignResult.fail(e.getMessage()));
 		}
 	}
 

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/dto/result/DeliveryAssignResult.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/dto/result/DeliveryAssignResult.java
@@ -1,0 +1,32 @@
+package com.winner.client.deliveryservice.deliverymanagerhub.application.dto.result;
+
+import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.commnad.AssignEventCommand;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+public class DeliveryAssignResult {
+
+	private final boolean success;
+	private final String errorMessage;
+	private final UUID deliveryId;
+	private final UUID orderId;
+
+	public static DeliveryAssignResult success(AssignEventCommand command) {
+		return DeliveryAssignResult.builder()
+			.success(true)
+			.deliveryId(command.deliveryId())
+			.orderId(command.orderId())
+			.build();
+	}
+
+	public static DeliveryAssignResult fail(String errorMessage) {
+		return DeliveryAssignResult.builder()
+			.success(false)
+			.errorMessage(errorMessage)
+			.build();
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/message/DeliveryMessagePort.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/message/DeliveryMessagePort.java
@@ -1,7 +1,6 @@
 package com.winner.client.deliveryservice.deliverymanagerhub.application.message;
 
 import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.result.DeliveryAssignResult;
-import java.util.UUID;
 
 public interface DeliveryMessagePort {
 	void assignEventPublish(DeliveryAssignResult result);

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/message/DeliveryMessagePort.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/message/DeliveryMessagePort.java
@@ -1,8 +1,8 @@
 package com.winner.client.deliveryservice.deliverymanagerhub.application.message;
 
+import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.result.DeliveryAssignResult;
 import java.util.UUID;
 
 public interface DeliveryMessagePort {
-	void failEventPublish(String message);
-	void successEventPublish(UUID deliveryId, UUID orderId);
+	void assignEventPublish(DeliveryAssignResult result);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryMessagePortImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryMessagePortImpl.java
@@ -4,7 +4,6 @@ import com.winner.client.deliveryservice.common.event.AssignFailEvent;
 import com.winner.client.deliveryservice.common.event.AssignSuccessEvent;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.result.DeliveryAssignResult;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.message.DeliveryMessagePort;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryMessagePortImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryMessagePortImpl.java
@@ -2,6 +2,7 @@ package com.winner.client.deliveryservice.deliverymanagerhub.infrastructure.mess
 
 import com.winner.client.deliveryservice.common.event.AssignFailEvent;
 import com.winner.client.deliveryservice.common.event.AssignSuccessEvent;
+import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.result.DeliveryAssignResult;
 import com.winner.client.deliveryservice.deliverymanagerhub.application.message.DeliveryMessagePort;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -12,15 +13,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeliveryMessagePortImpl implements DeliveryMessagePort {
 
-	private final ApplicationEventPublisher	publisher;
+	private final ApplicationEventPublisher publisher;
 
 	@Override
-	public void failEventPublish(String message) {
-		publisher.publishEvent(AssignFailEvent.from(message));
-	}
-
-	@Override
-	public void successEventPublish(UUID deliveryId, UUID orderId) {
-		publisher.publishEvent(AssignSuccessEvent.of(deliveryId, orderId));
+	public void assignEventPublish(DeliveryAssignResult result) {
+		if (result.isSuccess()) {
+			publisher.publishEvent(
+				AssignSuccessEvent.of(result.getDeliveryId(), result.getOrderId())
+			);
+		} else {
+			publisher.publishEvent(AssignFailEvent.from(result.getErrorMessage()));
+		}
 	}
 }


### PR DESCRIPTION
아래처럼 정리하면 팀원들이 빠르게 이해하기 좋습니다.  
`close #이슈번호`는 아직 이슈 번호를 모르니 **플레이스홀더**로 넣어둘게요.

---

### 📎 관련 이슈
- close #134

### 📌 작업 내용
- 배송 담당자 배정 처리 흐름을 리팩터링했습니다.
- 서비스 레이어에서 성공/실패 이벤트를 직접 구분해 발행하던 구조를 정리하고, **배정 결과를 `result`로 먼저 만들도록 변경**했습니다.
- 이후 이벤트 발행 책임은 `port`의 `assignEventPublish`에서 한 번에 처리하도록 통합했습니다.

### ✨ 변경 사항
- `DeliveryAssignResult` 추가
  - 배정 성공/실패 여부를 하나의 결과 객체로 관리
- 서비스 로직 변경
  - 성공 시/실패 시 각각 다른 메서드를 호출하던 방식 제거
  - 성공 또는 실패 결과만 만들어 `assignEventPublish(result)`로 전달
- 메시지 발행 구조 단순화
  - `port`에서 결과를 받아 `AssignSuccessEvent` / `AssignFailEvent` 발행을 담당

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항