### PR TITLE
[feat] hub-service에 securityLib 적용 및 Feign 기반 인증 전파 구현

### DIFF
--- a/hub-service/build.gradle
+++ b/hub-service/build.gradle
@@ -31,6 +31,8 @@ ext {
 
 dependencies {
     implementation project(':global')
+    implementation project(path: ':global', configuration: 'securityLib')
+    implementation project(path: ':global', configuration: 'feignLib')
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/hub-service/src/main/java/com/winner/client/hubservice/HubServiceApplication.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/HubServiceApplication.java
@@ -2,8 +2,13 @@ package com.winner.client.hubservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {
+	"com.winner.client.hubservice",
+	"com.winner.client.global"
+})
+@EnableFeignClients
 public class HubServiceApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
### 📎 관련 이슈
- close #140

### 📌 작업 내용
- hub-service에 `securityLib` 적용
- Gateway에서 전달되는 `X-User-*` 헤더를 기반으로 SecurityContext 자동 바인딩 설정
- `feignLib` 의존성 추가 및 Feign 인터셉터를 통한 인증 정보 자동 전파 구성
- global 패키지 스캔 설정 추가 (`scanBasePackages`)

### ✨ 변경 사항
- `build.gradle`
  - securityLib, feignLib 의존성 추가
- `HubServiceApplication`
  - global 패키지 포함하도록 설정 수정
  - FeignClient 활성화 설정 추가

### 📝 리뷰 포인트
- SecurityContext가 Gateway 헤더(`X-User-*`) 기반으로 정상 바인딩되는지
- Feign 호출 시 인증 정보가 정상적으로 전파되는지
- Gateway를 통해 요청 시 인증이 정상 동작하는지

### 🧠 기타 참고 사항
