### PR TITLE
[feat] 배송 이벤트 기반 구현

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignDeliveryManagerCompanyEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignDeliveryManagerCompanyEvent.java
@@ -1,0 +1,16 @@
+package com.winner.client.deliveryservice.common.event;
+
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
+import java.util.UUID;
+
+public record AssignDeliveryManagerCompanyEvent(
+    UUID deliveryId,
+    UUID toHubId
+) {
+  public static AssignDeliveryManagerCompanyEvent of(Delivery delivery) {
+    return new AssignDeliveryManagerCompanyEvent(
+        delivery.getId(),
+        delivery.getHubRoute().getDestinationHubId()
+    );
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignDeliveryManagerHubEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignDeliveryManagerHubEvent.java
@@ -1,0 +1,24 @@
+package com.winner.client.deliveryservice.common.event;
+
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
+import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
+import java.util.UUID;
+
+public record AssignDeliveryManagerHubEvent(
+    UUID deliveryId,
+    UUID deliveryRouteId
+) {
+  public static AssignDeliveryManagerHubEvent of(Delivery delivery, DeliveryRoute firstRoute) {
+    return new AssignDeliveryManagerHubEvent(
+        delivery.getId(),
+        firstRoute.getId()
+    );
+  }
+
+  public static AssignDeliveryManagerHubEvent of(DeliveryRoute firstRoute) {
+    return new AssignDeliveryManagerHubEvent(
+        firstRoute.getDelivery().getId(),
+        firstRoute.getId()
+    );
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompanyDeliveryManagerAssignFailCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompanyDeliveryManagerAssignFailCommand.java
@@ -1,0 +1,8 @@
+package com.winner.client.deliveryservice.delivery.application.dto.command;
+
+import java.util.UUID;
+
+public record CompanyDeliveryManagerAssignFailCommand(
+    String failReason,
+    UUID deliveryId
+) {}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/DeliveryAssignCompleteCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/DeliveryAssignCompleteCommand.java
@@ -1,0 +1,10 @@
+package com.winner.client.deliveryservice.delivery.application.dto.command;
+
+import java.util.UUID;
+
+public record DeliveryAssignCompleteCommand(
+    UUID deliveryId,
+    UUID deliveryManagerId,
+    String deliveryManagerName
+) {
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/DeliveryRouteAssignCompleteCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/DeliveryRouteAssignCompleteCommand.java
@@ -1,0 +1,10 @@
+package com.winner.client.deliveryservice.delivery.application.dto.command;
+
+import java.util.UUID;
+
+public record DeliveryRouteAssignCompleteCommand(
+    UUID deliveryRouteId,
+    UUID orderId,
+    UUID deliveryManagerId,
+    String deliveryManagerName
+) {}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/HubDeliveryManagerAssignFailCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/HubDeliveryManagerAssignFailCommand.java
@@ -1,0 +1,9 @@
+package com.winner.client.deliveryservice.delivery.application.dto.command;
+
+import java.util.UUID;
+
+public record HubDeliveryManagerAssignFailCommand(
+    String failReason,
+    UUID deliveryRouteId
+) {
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/port/DeliveryEventPort.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/port/DeliveryEventPort.java
@@ -1,0 +1,9 @@
+package com.winner.client.deliveryservice.delivery.application.port;
+
+import com.winner.client.deliveryservice.common.event.AssignDeliveryManagerCompanyEvent;
+import com.winner.client.deliveryservice.common.event.AssignDeliveryManagerHubEvent;
+
+public interface DeliveryEventPort {
+  void publishAssignHubEvent(AssignDeliveryManagerHubEvent event);
+  void publishAssignCompanyEvent(AssignDeliveryManagerCompanyEvent event);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryAssignmentService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryAssignmentService.java
@@ -1,0 +1,10 @@
+package com.winner.client.deliveryservice.delivery.application.service;
+
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
+import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
+
+public interface DeliveryAssignmentService {
+  void assignCompanyDeliveryManager(Delivery delivery);
+  void assignHubDeliveryManager(Delivery delivery);
+  void retryHubDeliveryManager(DeliveryRoute failedRoute);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryMessageUsecase.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryMessageUsecase.java
@@ -1,0 +1,13 @@
+package com.winner.client.deliveryservice.delivery.application.service;
+
+import com.winner.client.deliveryservice.delivery.application.dto.command.CompanyDeliveryManagerAssignFailCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryAssignCompleteCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.HubDeliveryManagerAssignFailCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryRouteAssignCompleteCommand;
+
+public interface DeliveryMessageUsecase {
+  void completeHubDeliveryManagerAssign(DeliveryRouteAssignCompleteCommand command);
+  void completeCompanyDeliveryManagerAssign(DeliveryAssignCompleteCommand command);
+  void retryHubDeliveryManagerAssign(HubDeliveryManagerAssignFailCommand command);
+  void retryCompanyDeliveryManagerAssign(CompanyDeliveryManagerAssignFailCommand command);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryAssignmentServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryAssignmentServiceImpl.java
@@ -1,0 +1,69 @@
+package com.winner.client.deliveryservice.delivery.application.service.impl;
+
+import com.winner.client.deliveryservice.common.event.AssignDeliveryManagerCompanyEvent;
+import com.winner.client.deliveryservice.common.event.AssignDeliveryManagerHubEvent;
+import com.winner.client.deliveryservice.common.exception.delivery.DeliveryErrorCode;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryRouteCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
+import com.winner.client.deliveryservice.delivery.application.port.DeliveryEventPort;
+import com.winner.client.deliveryservice.delivery.application.port.HubRoutePort;
+import com.winner.client.deliveryservice.delivery.application.service.DeliveryAssignmentService;
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
+import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
+import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
+import com.winner.client.global.exception.BusinessException;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryAssignmentServiceImpl implements DeliveryAssignmentService {
+
+  private final DeliveryRouteRepository deliveryRouteRepository;
+  private final HubRoutePort hubRoutePort;
+  private final DeliveryEventPort deliveryEventPort;
+
+  @Override
+  public void assignCompanyDeliveryManager(Delivery delivery) {
+    deliveryEventPort.publishAssignCompanyEvent(AssignDeliveryManagerCompanyEvent.of(delivery));
+  }
+
+  @Override
+  public void assignHubDeliveryManager(Delivery delivery) {
+    List<DeliveryRoute> routes = createAndSaveHubRoutes(delivery);
+
+    DeliveryRoute firstRoute = getFirstRoute(routes);
+
+    deliveryEventPort.publishAssignHubEvent(AssignDeliveryManagerHubEvent.of(delivery, firstRoute));
+  }
+
+  @Override
+  public void retryHubDeliveryManager(DeliveryRoute failedRoute) {
+    deliveryEventPort.publishAssignHubEvent(
+        AssignDeliveryManagerHubEvent.of(failedRoute));
+  }
+
+  private List<DeliveryRoute> createAndSaveHubRoutes(Delivery delivery) {
+    List<DeliveryRoute> routes = getDeliveryHubRoute(delivery);
+    routes.forEach(deliveryRouteRepository::save);
+    return routes;
+  }
+
+  private List<DeliveryRoute> getDeliveryHubRoute(Delivery delivery) {
+    HubRouteInfo hubRouteInfo = hubRoutePort.
+        getHubRoutes(delivery.getHubRoute().getOriginHubId(), delivery.getHubRoute().getDestinationHubId());
+
+    return CreateDeliveryRouteCommand.of(delivery, hubRouteInfo)
+        .stream()
+        .map(DeliveryRoute::create)
+        .toList();
+  }
+
+  private DeliveryRoute getFirstRoute(List<DeliveryRoute> routes) {
+    return routes.stream()
+        .min(Comparator.comparingInt(DeliveryRoute::getSeq))
+        .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY_ROUTE));
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryCommandServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryCommandServiceImpl.java
@@ -2,19 +2,14 @@ package com.winner.client.deliveryservice.delivery.application.service.impl;
 
 import com.winner.client.deliveryservice.common.exception.delivery.DeliveryErrorCode;
 import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryCommand;
-import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryRouteCommand;
-import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
 import com.winner.client.deliveryservice.delivery.application.dto.result.CreateDeliveryResult;
-import com.winner.client.deliveryservice.delivery.application.port.HubRoutePort;
+import com.winner.client.deliveryservice.delivery.application.service.DeliveryAssignmentService;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryCommandService;
 import com.winner.client.deliveryservice.delivery.application.validator.DeliveryAccessValidator;
 import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
-import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRepository;
-import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
 import com.winner.client.deliveryservice.delivery.presentation.dto.response.DeliveryCommandResponse;
 import com.winner.client.global.exception.BusinessException;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,8 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeliveryCommandServiceImpl implements DeliveryCommandService {
 
   private final DeliveryRepository deliveryRepository;
-  private final DeliveryRouteRepository deliveryRouteRepository;
-  private final HubRoutePort hubRoutePort;
+  private final DeliveryAssignmentService deliveryAssignmentService;
   private final DeliveryAccessValidator validator;
 
   @Override
@@ -36,19 +30,14 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
       throw new BusinessException(DeliveryErrorCode.ALREADY_DELIVERY_ASSIGNED);
     }
 
-    Delivery delivery =
-        Delivery.create(command.ordersId(), command.hubRoute(),
-            command.receiver(), command.address(), null);
+    Delivery delivery = Delivery.create(
+        command.ordersId(), command.hubRoute(), command.receiver(), command.address(), null);
 
-    HubRouteInfo hubRouteInfo = hubRoutePort.
-        getHubRoutes(delivery.getHubRoute().getOriginHubId(), delivery.getHubRoute().getDestinationHubId());
-
-    List<CreateDeliveryRouteCommand> routeCommands = CreateDeliveryRouteCommand.of(delivery, hubRouteInfo);
-    routeCommands.forEach(routeCommand -> {
-      DeliveryRoute route =
-          DeliveryRoute.create(routeCommand);
-      deliveryRouteRepository.save(route);
-    });
+    if (delivery.isSameHub()) {
+      deliveryAssignmentService.assignCompanyDeliveryManager(delivery);
+    } else {
+      deliveryAssignmentService.assignHubDeliveryManager(delivery);
+    }
 
     deliveryRepository.save(delivery);
     return CreateDeliveryResult.from(delivery);
@@ -117,5 +106,4 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
     return deliveryRepository.findByIdWithRoutes(deliveryId)
         .orElseThrow(()-> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY));
   }
-
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryMessageServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryMessageServiceImpl.java
@@ -1,0 +1,70 @@
+package com.winner.client.deliveryservice.delivery.application.service.impl;
+
+import com.winner.client.deliveryservice.common.exception.delivery.DeliveryErrorCode;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CompanyDeliveryManagerAssignFailCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryAssignCompleteCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryRouteAssignCompleteCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.HubDeliveryManagerAssignFailCommand;
+import com.winner.client.deliveryservice.delivery.application.service.DeliveryMessageUsecase;
+import com.winner.client.deliveryservice.delivery.application.service.DeliveryAssignmentService;
+import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
+import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
+import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRepository;
+import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
+import com.winner.client.global.exception.BusinessException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryMessageServiceImpl implements DeliveryMessageUsecase {
+
+  private final DeliveryRepository deliveryRepository;
+  private final DeliveryRouteRepository deliveryRouteRepository;
+  private final DeliveryAssignmentService deliveryAssignmentService;
+
+  @Override
+  @Transactional
+  public void completeHubDeliveryManagerAssign(DeliveryRouteAssignCompleteCommand command) {
+    DeliveryRoute route = findDeliveryRouteById(command.deliveryRouteId());
+    route.updateDeliveryManagerInfo(command.deliveryManagerId(), command.deliveryManagerName());
+    // todo: order 배송 담당자 정보 update
+  }
+
+  @Override
+  @Transactional
+  public void completeCompanyDeliveryManagerAssign(DeliveryAssignCompleteCommand command) {
+    Delivery delivery = findDeliveryById(command.deliveryId());
+
+    delivery.updateDeliveryManagerInfo(command.deliveryManagerId(), command.deliveryManagerName());
+    // todo: order 배송 담당자 정보 update
+  }
+
+  @Override
+  public void retryHubDeliveryManagerAssign(HubDeliveryManagerAssignFailCommand command) {
+    DeliveryRoute failedRoute = findDeliveryRouteById(command.deliveryRouteId());
+
+    deliveryAssignmentService.retryHubDeliveryManager(failedRoute);
+  }
+
+  @Override
+  public void retryCompanyDeliveryManagerAssign(CompanyDeliveryManagerAssignFailCommand command) {
+    Delivery delivery = findDeliveryById(command.deliveryId());
+
+    deliveryAssignmentService.assignCompanyDeliveryManager(delivery);
+  }
+
+  private Delivery findDeliveryById(UUID deliveryId) {
+    return deliveryRepository.findById(deliveryId)
+        .orElseThrow(()-> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY));
+  }
+
+  private DeliveryRoute findDeliveryRouteById(UUID deliveryId) {
+    return deliveryRouteRepository.findById(deliveryId)
+        .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY_ROUTE));
+
+  }
+
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryQueryServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryQueryServiceImpl.java
@@ -11,13 +11,8 @@ import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRepository;
 import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
 import com.winner.client.deliveryservice.delivery.infrastructure.repository.custom.DeliveryCustomRepository;
-import com.winner.client.deliveryservice.delivery.presentation.dto.response.DeliveryInfoResponse;
 import com.winner.client.deliveryservice.delivery.presentation.dto.response.DeliveryRouteInfoResponse;
-import com.winner.client.deliveryservice.delivery.presentation.dto.response.GetDeliveryResponse;
-import com.winner.client.deliveryservice.delivery.presentation.dto.response.GetDeliveryRouteResponse;
-import com.winner.client.deliveryservice.delivery.presentation.dto.response.ListDeliveryRouteResponse;
 import com.winner.client.global.exception.BusinessException;
-import com.winner.client.global.pagination.CommonPageRequest;
 import com.winner.client.global.pagination.PageResponse;
 import java.util.List;
 import java.util.UUID;
@@ -44,6 +39,10 @@ public class DeliveryQueryServiceImpl implements DeliveryQueryService {
   public List<FindDeliveryRouteResult> getDeliveryRoutes(UUID deliveryId) {
     validateDeliveryExists(deliveryId);
     List<DeliveryRoute> routes = deliveryRouteRepository.findAllByDeliveryId(deliveryId);
+
+    if (routes.isEmpty()) {
+      return List.of();
+    }
 
     return routes.stream().map(FindDeliveryRouteResult::from).toList();
   }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/Delivery.java
@@ -128,6 +128,15 @@ public class Delivery extends BaseAuditEntity {
     return hubRoute.isRelatedTo(hubId);
   }
 
+  public boolean isSameHub() {
+    return hubRoute.isSameHub();
+  }
+
+  public void updateDeliveryManagerInfo(UUID deliveryManagerId, String DeliveryManagerName) {
+    this.deliveryManagerId = deliveryManagerId;
+    this.DeliveryManagerName = DeliveryManagerName;
+  }
+
   private Delivery(
       UUID ordersId, HubRoute hubRoute, Receiver receiver,
       Address address, Location location) {

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/DeliveryRoute.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/DeliveryRoute.java
@@ -131,6 +131,11 @@ public class DeliveryRoute {
     this.actualArrivalTime = new Duration(actualArrivalTime);
   }
 
+  public void updateDeliveryManagerInfo(UUID deliveryManagerId, String DeliveryManagerName) {
+    this.deliveryManagerId = deliveryManagerId;
+    this.DeliveryManagerName = DeliveryManagerName;
+  }
+
   public DeliveryRoute(Delivery delivery, int seq, CurrentHubRoute currentHubRoute,
       String curHubName, String nextHubName, Distance estimatedDistance, Duration estimatedArrivalTime) {
     this.delivery = delivery;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/HubRoute.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/vo/HubRoute.java
@@ -28,4 +28,8 @@ public class HubRoute {
     if (hubId == null) return false;
     return originHubId.equals(hubId) || destinationHubId.equals(hubId);
   }
+
+  public boolean isSameHub() {
+    return originHubId.equals(destinationHubId);
+  }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/message/DeliveryEventAdapter.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/message/DeliveryEventAdapter.java
@@ -1,0 +1,25 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.message;
+
+import com.winner.client.deliveryservice.common.event.AssignDeliveryManagerCompanyEvent;
+import com.winner.client.deliveryservice.common.event.AssignDeliveryManagerHubEvent;
+import com.winner.client.deliveryservice.delivery.application.port.DeliveryEventPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryEventAdapter implements DeliveryEventPort {
+
+  private final ApplicationEventPublisher eventPublisher;
+
+  @Override
+  public void publishAssignHubEvent(AssignDeliveryManagerHubEvent event) {
+    eventPublisher.publishEvent(event);
+  }
+
+  @Override
+  public void publishAssignCompanyEvent(AssignDeliveryManagerCompanyEvent event) {
+    eventPublisher.publishEvent(event);
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/message/DeliverySpringEventListener.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/message/DeliverySpringEventListener.java
@@ -1,0 +1,23 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.message;
+
+import com.winner.client.deliveryservice.common.event.AssignFailEvent;
+import com.winner.client.deliveryservice.common.event.AssignSuccessEvent;
+import com.winner.client.deliveryservice.delivery.application.service.DeliveryMessageUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliverySpringEventListener {
+
+	private final DeliveryMessageUsecase usecase;
+
+	@EventListener
+	public void successEventPublish(AssignSuccessEvent event) {
+	}
+
+	@EventListener
+	public void failEventPublish(AssignFailEvent event) {
+	}
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #114 

### 📌 작업 내용
- 배송 담당자 배정 로직을 이벤트 기반 구조로 구현하였다.
- 배정 요청, 처리, 결과 반영을 단계적으로 나누어 책임을 명확히 하고 확장 가능하도록 작성하였다.

```
[추가된 파일]
- CompanyDeliveryManagerAssignFailCommand.java
- DeliveryAssignCompleteCommand.java
- DeliveryRouteAssignCompleteCommand.java
- HubDeliveryManagerAssignFailCommand.java
- DeliveryEventPort.java
- DeliveryMessageUsecase.java
- DeliveryAssignmentServiceImpl.java
- DeliveryMessageServiceImpl.java
- DeliveryEventAdapter.java
- DeliverySpringEventListener.java
```

### ✨ 변경 사항
**[변경 흐름]**
1.   배송 또는 배송 경로 생성
2.   배송 담당자 배정 요청 이벤트 발행
3.   이벤트 리스너가 이벤트 수신
4.   배정 처리 수행
5.   배정 성공 또는 실패 결과를 Command로 전달
6. [성공]
배송 및 배송 경로 상태 변경
주문 서비스에 배송 담당자 정보 업데이트
7. [실패]
허브 또는 업체 배송 담당자 재배정 이벤트 발행

**[주요 변경 내용 정리]**
이벤트 정의
- `AssignDeliveryManagerCompanyEvent` 업체 배송 담당자 배정을 요청하는 이벤트 객체
- `AssignDeliveryManagerHubEvent` 허브 배송 담당자 배정을 요청하는 이벤트 객체

이벤트 발생
- `DeliveryEventPort` 이벤트 발행을 위한 인터페이스
- `DeliveryEventAdapter` `DeliveryEventPort`의 구현체

이벤트 수신
- `DeliverySpringEventListener `배정 요청 이벤트를 수신하고 실제 배정 처리 로직을 실행

배정 결과 처리 Command
- `DeliveryAssignCompleteCommand`
- `DeliveryRouteAssignCompleteCommand`
- `CompanyDeliveryManagerAssignFailCommand`
- `HubDeliveryManagerAssignFailCommand`
→ 배정 결과(성공/실패)에 따라 상태 변경을 수행하기 위한 Command 객체

이벤트 처리
- `DeliveryMessageUsecase` 이벤트 기반 처리 흐름을 정의한 인터페이스
- `DeliveryMessageServiceImpl` 이벤트 처리 실제 구현체

### 📝 리뷰 포인트 (선택)
- 이벤트 기반 구조로 분리하면서 책임 분리가 적절하게 이루어졌는지
- 배정 실패 시 재배정 이벤트 흐름이 자연스러운지

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)
- 이벤트 성공에 따라 Feign Client를 통해 order 정보를 update.
- 불필요한 상태 값 제거
- 배송 완료 이벤트를 받아 처리하는 로직 추가 예정