### PR TITLE
[feat] 허브 수정 및 삭제 기능 구현 (Soft Delete 적용)

### DIFF
--- a/hub-service/src/main/java/com/winner/client/hubservice/config/AuditorConfig.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/config/AuditorConfig.java
@@ -1,0 +1,34 @@
+package com.winner.client.hubservice.config;
+
+import com.winner.client.global.security.CustomUserPrincipal;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Configuration
+public class AuditorConfig {
+
+    @Bean
+    public AuditorAware<UUID> auditorProvider() {
+        return () -> {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            if (authentication == null) {
+                return Optional.empty();
+            }
+
+            Object principal = authentication.getPrincipal();
+
+            if (!(principal instanceof CustomUserPrincipal)) {
+                return Optional.empty();
+            }
+
+            CustomUserPrincipal user = (CustomUserPrincipal) principal;
+            return Optional.of(user.userId());
+        };
+    }
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubPathService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubPathService.java
@@ -37,7 +37,7 @@ public class HubPathService {
 
         for (UUID hubId : result.path) {
 
-            String hubName = hubRepository.findById(hubId)
+            String hubName = hubRepository.findByIdAndDeletedAtIsNull(hubId)
                 .map(hub -> hub.getName())
                 .orElse("UNKNOWN");
 
@@ -70,11 +70,11 @@ public class HubPathService {
             UUID fromHubId = result.path.get(i);
             UUID toHubId = result.path.get(i + 1);
 
-            String fromName = hubRepository.findById(fromHubId)
+            String fromName = hubRepository.findByIdAndDeletedAtIsNull(fromHubId)
                 .map(h -> h.getName())
                 .orElse("UNKNOWN");
 
-            String toName = hubRepository.findById(toHubId)
+            String toName = hubRepository.findByIdAndDeletedAtIsNull(toHubId)
                 .map(h -> h.getName())
                 .orElse("UNKNOWN");
 

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubRouteService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubRouteService.java
@@ -36,7 +36,7 @@ public class HubRouteService {
 
     @Transactional(readOnly = true)
     public List<HubRouteResult> getAllRoutes() {
-        return hubRouteRepository.findAll().stream()
+        return hubRouteRepository.findAllByDeletedAtIsNull().stream()
             .map(route -> HubRouteResult.builder()
                 .id(route.getId())
                 .fromHubId(route.getRouteInfo().getFromHubId())

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubRouteService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubRouteService.java
@@ -49,7 +49,7 @@ public class HubRouteService {
 
     @Transactional(readOnly = true)
     public List<HubRouteResult> searchRoutes(UUID fromHubId, UUID toHubId) {
-        return hubRouteRepository.findByRouteInfo_FromHubIdAndRouteInfo_ToHubId(fromHubId, toHubId).stream()
+        return hubRouteRepository.findByRouteInfo_FromHubIdAndRouteInfo_ToHubIdAndDeletedAtIsNull(fromHubId, toHubId).stream()
             .map(route -> HubRouteResult.builder()
                 .id(route.getId())
                 .fromHubId(route.getRouteInfo().getFromHubId())

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
@@ -4,6 +4,7 @@ import com.winner.client.hubservice.common.exception.hub.HubErrorCode;
 import com.winner.client.hubservice.common.exception.hub.HubException;
 import com.winner.client.hubservice.hub.application.dto.CreateHubCommand;
 import com.winner.client.hubservice.hub.application.dto.HubResult;
+import com.winner.client.hubservice.hub.application.dto.UpdateHubCommand;
 import com.winner.client.hubservice.hub.domain.entity.Hub;
 import com.winner.client.hubservice.hub.domain.repository.HubRepository;
 import com.winner.client.hubservice.hub.domain.vo.HubLocation;
@@ -36,7 +37,7 @@ public class HubService {
     }
 
     public HubResult getHub(UUID hubId) {
-        Hub hub = hubRepository.findById(hubId)
+        Hub hub = hubRepository.findByIdAndDeletedAtIsNull(hubId)
             .orElseThrow(()-> new HubException(HubErrorCode.HUB_NOT_FOUND));
 
         return HubResult.builder()
@@ -46,5 +47,24 @@ public class HubService {
             .lat(hub.getLocation().getLat())
             .lng(hub.getLocation().getLng())
             .build();
+    }
+
+    @Transactional
+    public void updateHub(UUID hubId, UpdateHubCommand command) {
+        Hub hub = hubRepository.findByIdAndDeletedAtIsNull(hubId)
+            .orElseThrow(()-> new HubException(HubErrorCode.HUB_NOT_FOUND));
+
+        if (!hub.getName().equals(command.getName()) &&
+            hubRepository.existsByNameAndDeletedAtIsNull(command.getName())) {
+            throw new HubException(HubErrorCode.DUPLICATE_HUB);
+        }
+
+        HubLocation location = new HubLocation(
+            command.getAddress(),
+            command.getLat(),
+            command.getLng()
+        );
+
+        hub.update(command.getName(), location);
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
@@ -7,6 +7,7 @@ import com.winner.client.hubservice.hub.application.dto.HubResult;
 import com.winner.client.hubservice.hub.application.dto.UpdateHubCommand;
 import com.winner.client.hubservice.hub.domain.entity.Hub;
 import com.winner.client.hubservice.hub.domain.repository.HubRepository;
+import com.winner.client.hubservice.hub.domain.repository.HubRouteRepository;
 import com.winner.client.hubservice.hub.domain.vo.HubLocation;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class HubService {
 
     private final HubRepository hubRepository;
+    private final HubRouteRepository hubRouteRepository;
 
     @Transactional
     public UUID createHub(CreateHubCommand command) {
@@ -66,5 +68,20 @@ public class HubService {
         );
 
         hub.update(command.getName(), location);
+    }
+
+    @Transactional
+    public void deleteHub(UUID hubId, UUID userId) {
+        Hub hub = hubRepository.findByIdAndDeletedAtIsNull(hubId)
+            .orElseThrow(()-> new HubException(HubErrorCode.HUB_NOT_FOUND));
+
+        hub.delete(userId);
+
+        var routes = hubRouteRepository
+            .findAllByRouteInfo_FromHubIdOrRouteInfo_ToHubIdAndDeletedAtIsNull(hubId, hubId);
+
+        for (var route : routes) {
+            route.delete(userId);
+        }
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
@@ -27,7 +27,7 @@ public class HubService {
             command.getLng()
         );
 
-        if (hubRepository.existsByName(command.getName())) {
+        if (hubRepository.existsByNameAndDeletedAtIsNull(command.getName())) {
             throw new HubException(HubErrorCode.DUPLICATE_HUB);
         }
 

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/dto/UpdateHubCommand.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/dto/UpdateHubCommand.java
@@ -1,0 +1,19 @@
+package com.winner.client.hubservice.hub.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateHubCommand {
+
+    private String name;
+    private String address;
+    private double lat;
+    private double lng;
+
+    public UpdateHubCommand(String name, String address, double lat, double lng) {
+        this.name = name;
+        this.address = address;
+        this.lat = lat;
+        this.lng = lng;
+    }
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/dto/UpdateHubCommand.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/dto/UpdateHubCommand.java
@@ -1,5 +1,6 @@
 package com.winner.client.hubservice.hub.application.dto;
 
+import com.winner.client.hubservice.hub.presentation.dto.UpdateHubRequest;
 import lombok.Getter;
 
 @Getter
@@ -15,5 +16,14 @@ public class UpdateHubCommand {
         this.address = address;
         this.lat = lat;
         this.lng = lng;
+    }
+
+    public static UpdateHubCommand from(UpdateHubRequest request) {
+        return new UpdateHubCommand(
+            request.getName(),
+            request.getAddress(),
+            request.getLat(),
+            request.getLng()
+        );
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/Hub.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/Hub.java
@@ -44,4 +44,12 @@ public class Hub extends BaseAuditEntity {
     public static Hub create(String name, HubLocation location) {
         return new Hub(name, location);
     }
+
+    public void update(String name, HubLocation location) {
+        if (name == null || name.isBlank()) {
+            throw new HubException(HubErrorCode.INVALID_HUB_NAME);
+        }
+        this.name = name;
+        this.location = location;
+    }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/Hub.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/Hub.java
@@ -1,5 +1,6 @@
 package com.winner.client.hubservice.hub.domain.entity;
 
+import com.winner.client.global.entity.BaseAuditEntity;
 import com.winner.client.hubservice.common.exception.hub.HubErrorCode;
 import com.winner.client.hubservice.common.exception.hub.HubException;
 import com.winner.client.hubservice.hub.domain.vo.HubLocation;
@@ -16,7 +17,7 @@ import org.hibernate.annotations.UuidGenerator;
 @Entity
 @Getter
 @Table(name = "p_hubs")
-public class Hub {
+public class Hub extends BaseAuditEntity {
 
     @Id
     @GeneratedValue
@@ -24,7 +25,7 @@ public class Hub {
     @Column(name = "id", nullable = false)
     private UUID id;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name", nullable = false, unique = true)
     private String name;
 
     @Embedded

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/Hub.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/Hub.java
@@ -25,7 +25,7 @@ public class Hub extends BaseAuditEntity {
     @Column(name = "id", nullable = false)
     private UUID id;
 
-    @Column(name = "name", nullable = false, unique = true)
+    @Column(name = "name", nullable = false)
     private String name;
 
     @Embedded
@@ -51,5 +51,9 @@ public class Hub extends BaseAuditEntity {
         }
         this.name = name;
         this.location = location;
+    }
+
+    public void delete(UUID userId) {
+        super.softDelete(userId);
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/HubRoute.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/HubRoute.java
@@ -55,4 +55,8 @@ public class HubRoute extends BaseAuditEntity {
     public static HubRoute create(RouteInfo routeInfo, Distance distance, Duration duration) {
         return new HubRoute(routeInfo, distance, duration);
     }
+
+    public void delete(UUID userId) {
+        super.softDelete(userId);
+    }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/HubRoute.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/entity/HubRoute.java
@@ -1,5 +1,6 @@
 package com.winner.client.hubservice.hub.domain.entity;
 
+import com.winner.client.global.entity.BaseAuditEntity;
 import com.winner.client.hubservice.hub.domain.vo.Distance;
 import com.winner.client.hubservice.hub.domain.vo.Duration;
 import com.winner.client.hubservice.hub.domain.vo.RouteInfo;
@@ -23,7 +24,7 @@ import org.hibernate.annotations.UuidGenerator;
         columnNames = {"from_hub_id", "to_hub_id"}
     )
 )
-public class HubRoute {
+public class HubRoute extends BaseAuditEntity {
 
     @Id
     @GeneratedValue

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRepository.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRepository.java
@@ -1,10 +1,17 @@
 package com.winner.client.hubservice.hub.domain.repository;
 
 import com.winner.client.hubservice.hub.domain.entity.Hub;
+import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HubRepository extends JpaRepository<Hub, UUID> {
 
-    boolean existsByName(String name);
+    boolean existsByNameAndDeletedAtIsNull(String name);
+
+    Optional<Hub> findByIdAndDeletedAtIsNull(UUID id);
+
+    Page<Hub> findAllByDeletedAtIsNull(Pageable pageable);
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRepository.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRepository.java
@@ -5,9 +5,10 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HubRepository extends JpaRepository<Hub, UUID> {
+public interface HubRepository {
+
+    Hub save(Hub hub);
 
     boolean existsByNameAndDeletedAtIsNull(String name);
 

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRouteRepository.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRouteRepository.java
@@ -2,13 +2,18 @@ package com.winner.client.hubservice.hub.domain.repository;
 
 import com.winner.client.hubservice.hub.domain.entity.HubRoute;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HubRouteRepository extends JpaRepository<HubRoute, UUID> {
 
-    List<HubRoute> findByRouteInfo_FromHubIdAndRouteInfo_ToHubId(
+    List<HubRoute> findByRouteInfo_FromHubIdAndRouteInfo_ToHubIdAndDeletedAtIsNull(
         UUID fromHubId,
         UUID toHubId
     );
+
+    Optional<HubRoute> findByIdAndDeletedAtIsNull(UUID id);
+
+    List<HubRoute> findAllByDeletedAtIsNull();
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRouteRepository.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRouteRepository.java
@@ -16,4 +16,9 @@ public interface HubRouteRepository extends JpaRepository<HubRoute, UUID> {
     Optional<HubRoute> findByIdAndDeletedAtIsNull(UUID id);
 
     List<HubRoute> findAllByDeletedAtIsNull();
+
+    List<HubRoute> findAllByRouteInfo_FromHubIdOrRouteInfo_ToHubIdAndDeletedAtIsNull(
+        UUID fromHubId,
+        UUID toHubId
+    );
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRouteRepository.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRouteRepository.java
@@ -4,9 +4,12 @@ import com.winner.client.hubservice.hub.domain.entity.HubRoute;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HubRouteRepository extends JpaRepository<HubRoute, UUID> {
+public interface HubRouteRepository {
+
+    HubRoute save(HubRoute route);
+
+    List<HubRoute> findAll();
 
     List<HubRoute> findByRouteInfo_FromHubIdAndRouteInfo_ToHubIdAndDeletedAtIsNull(
         UUID fromHubId,

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/graph/HubGraphBuilder.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/graph/HubGraphBuilder.java
@@ -15,7 +15,7 @@ public class HubGraphBuilder {
     private final HubRouteRepository hubRouteRepository;
 
     public HubGraph build() {
-        List<HubRoute> routes = hubRouteRepository.findAll();
+        List<HubRoute> routes = hubRouteRepository.findAllByDeletedAtIsNull();
 
         HubGraph graph = new HubGraph();
 

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/repository/JpaHubRepository.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/repository/JpaHubRepository.java
@@ -1,0 +1,10 @@
+package com.winner.client.hubservice.hub.infrastructure.repository;
+
+import com.winner.client.hubservice.hub.domain.entity.Hub;
+import com.winner.client.hubservice.hub.domain.repository.HubRepository;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaHubRepository extends JpaRepository<Hub, UUID>, HubRepository {
+
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/repository/JpaHubRouteRepository.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/repository/JpaHubRouteRepository.java
@@ -1,0 +1,10 @@
+package com.winner.client.hubservice.hub.infrastructure.repository;
+
+import com.winner.client.hubservice.hub.domain.entity.HubRoute;
+import com.winner.client.hubservice.hub.domain.repository.HubRouteRepository;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaHubRouteRepository extends JpaRepository<HubRoute, UUID>, HubRouteRepository {
+
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubController.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubController.java
@@ -3,11 +3,14 @@ package com.winner.client.hubservice.hub.presentation;
 import com.winner.client.hubservice.hub.application.HubService;
 import com.winner.client.hubservice.hub.application.dto.CreateHubCommand;
 import com.winner.client.hubservice.hub.application.dto.HubResult;
+import com.winner.client.hubservice.hub.application.dto.UpdateHubCommand;
 import com.winner.client.hubservice.hub.presentation.dto.CreateHubRequest;
 import com.winner.client.hubservice.hub.presentation.dto.HubResponse;
+import com.winner.client.hubservice.hub.presentation.dto.UpdateHubRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,5 +47,17 @@ public class HubController {
             .lat(result.getLat())
             .lng(result.getLng())
             .build();
+    }
+
+    @PatchMapping("/{hubId}")
+    public void updateHub(@PathVariable UUID hubId, @RequestBody UpdateHubRequest request) {
+        UpdateHubCommand command = new UpdateHubCommand(
+            request.getName(),
+            request.getAddress(),
+            request.getLat(),
+            request.getLng()
+        );
+
+        hubService.updateHub(hubId, command);
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubController.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubController.java
@@ -1,5 +1,6 @@
 package com.winner.client.hubservice.hub.presentation;
 
+import com.winner.client.global.security.CustomUserPrincipal;
 import com.winner.client.hubservice.hub.application.HubService;
 import com.winner.client.hubservice.hub.application.dto.CreateHubCommand;
 import com.winner.client.hubservice.hub.application.dto.HubResult;
@@ -9,13 +10,13 @@ import com.winner.client.hubservice.hub.presentation.dto.HubResponse;
 import com.winner.client.hubservice.hub.presentation.dto.UpdateHubRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -59,7 +60,7 @@ public class HubController {
     }
 
     @DeleteMapping("/{hubId}")
-    public void deleteHub(@PathVariable UUID hubId, @RequestHeader("X-User-Id") UUID userId) {
-        hubService.deleteHub(hubId, userId);
+    public void deleteHub(@PathVariable UUID hubId, @AuthenticationPrincipal CustomUserPrincipal user) {
+        hubService.deleteHub(hubId, user.userId());
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubController.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubController.java
@@ -53,12 +53,7 @@ public class HubController {
 
     @PatchMapping("/{hubId}")
     public void updateHub(@PathVariable UUID hubId, @RequestBody UpdateHubRequest request) {
-        UpdateHubCommand command = new UpdateHubCommand(
-            request.getName(),
-            request.getAddress(),
-            request.getLat(),
-            request.getLng()
-        );
+        UpdateHubCommand command = UpdateHubCommand.from(request);
 
         hubService.updateHub(hubId, command);
     }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubController.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubController.java
@@ -9,11 +9,13 @@ import com.winner.client.hubservice.hub.presentation.dto.HubResponse;
 import com.winner.client.hubservice.hub.presentation.dto.UpdateHubRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -59,5 +61,10 @@ public class HubController {
         );
 
         hubService.updateHub(hubId, command);
+    }
+
+    @DeleteMapping("/{hubId}")
+    public void deleteHub(@PathVariable UUID hubId, @RequestHeader("X-User-Id") UUID userId) {
+        hubService.deleteHub(hubId, userId);
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/dto/UpdateHubRequest.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/dto/UpdateHubRequest.java
@@ -1,0 +1,12 @@
+package com.winner.client.hubservice.hub.presentation.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateHubRequest {
+
+    private String name;
+    private String address;
+    private double lat;
+    private double lng;
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #146

### 📌 작업 내용
- 허브 수정(Update) API 구현
- 허브 삭제(Delete) API 구현 (Soft Delete 적용)
- BaseAuditEntity 기반 audit 필드(createdAt, updatedAt, deletedAt, createdBy, deletedBy) 적용
- 허브 삭제 시 연관된 HubRoute 데이터도 함께 soft delete 처리 (연쇄 삭제)
- 허브 이름 중복 검증 로직 추가 (existsByNameAndDeletedAtIsNull)
- 삭제된 데이터는 조회되지 않도록 조회 조건 적용

### ✨ 변경 사항
- Hub 엔티티에 soft delete 로직 추가
- HubRoute 엔티티에도 soft delete 적용
- HubService에 update / delete 로직 추가
- HubRouteRepository에 허브 기준 경로 조회 메서드 추가
- HubController에 PATCH / DELETE API 추가

### 📝 리뷰 포인트
- soft delete 방식으로 구현한 삭제 로직이 적절한지
- Hub 삭제 시 HubRoute 연쇄 삭제 처리 방식이 적절한지
- Service에서 Repository 직접 사용하는 구조에 대한 의견

### 🧠 기타 참고 사항
- 삭제된 데이터는 deletedAt 기준으로 조회에서 제외되도록 구현했습니다.
- DB unique 제약 대신 서비스 레벨에서 중복 검증을 처리했습니다.