### PR TITLE
[feat] 허브 삭제 시 user-service 연동 (사용자 소속 해제)

### DIFF
--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
@@ -5,6 +5,7 @@ import com.winner.client.hubservice.common.exception.hub.HubException;
 import com.winner.client.hubservice.hub.application.dto.CreateHubCommand;
 import com.winner.client.hubservice.hub.application.dto.HubResult;
 import com.winner.client.hubservice.hub.application.dto.UpdateHubCommand;
+import com.winner.client.hubservice.hub.application.port.UserPort;
 import com.winner.client.hubservice.hub.domain.entity.Hub;
 import com.winner.client.hubservice.hub.domain.repository.HubRepository;
 import com.winner.client.hubservice.hub.domain.repository.HubRouteRepository;
@@ -21,6 +22,7 @@ public class HubService {
 
     private final HubRepository hubRepository;
     private final HubRouteRepository hubRouteRepository;
+    private final UserPort userPort;
 
     @Transactional
     public UUID createHub(CreateHubCommand command) {
@@ -74,6 +76,9 @@ public class HubService {
     public void deleteHub(UUID hubId, UUID userId) {
         Hub hub = hubRepository.findByIdAndDeletedAtIsNull(hubId)
             .orElseThrow(()-> new HubException(HubErrorCode.HUB_NOT_FOUND));
+
+        // TODO: 허브에 속한 사용자 목록 조회 후 전체 unassign 처리 필요
+        userPort.unassignUser(userId);
 
         hub.delete(userId);
 

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/port/UserPort.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/port/UserPort.java
@@ -1,0 +1,8 @@
+package com.winner.client.hubservice.hub.application.port;
+
+import java.util.UUID;
+
+public interface UserPort {
+
+    void unassignUser(UUID userId);
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/client/UserClient.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/client/UserClient.java
@@ -1,0 +1,13 @@
+package com.winner.client.hubservice.hub.infrastructure.client;
+
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name="user-service")
+public interface UserClient {
+
+    @PatchMapping("/internal/v1/users/{userId}/unassign")
+    void unassignUser(@PathVariable UUID userId);
+}

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/client/UserClientAdapter.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/client/UserClientAdapter.java
@@ -1,0 +1,18 @@
+package com.winner.client.hubservice.hub.infrastructure.client;
+
+import com.winner.client.hubservice.hub.application.port.UserPort;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserClientAdapter implements UserPort {
+
+    private final UserClient userClient;
+
+    @Override
+    public void unassignUser(UUID userId) {
+        userClient.unassignUser(userId);
+    }
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #160

### 📌 작업 내용
- 허브 삭제 시 user-service와 연동하여 사용자 소속 해제 기능 구현
- FeignClient를 활용한 서비스 간 통신 구성
- Port-Adapter 구조(UserPort, UserClientAdapter) 적용
- HubService에서 user-service 호출 로직 추가

### ✨ 변경 사항
- UserPort 인터페이스 추가
- UserClient (Feign) 구현
- UserClientAdapter 추가 (Port → Feign 연결)
- HubService delete 로직에 user-service 호출 추가

### 📝 리뷰 포인트
- FeignClient 기반 서비스 간 통신 구조 적절성
- Port-Adapter 구조 적용 방식
- HubService에서 외부 서비스 호출 위치 적절성

### 🧠 기타 참고 사항
- 현재는 단일 사용자(userId) 기준으로 unassign 처리
- 허브에 속한 전체 사용자 처리 로직은 추후 확장 예정