### PR TITLE
[feat]: 배송담당자 배정 이벤트 정보에 매니저 아이디 추가 & 주문 아이디 삭제

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignSuccessEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignSuccessEvent.java
@@ -4,9 +4,9 @@ import java.util.UUID;
 
 public record AssignSuccessEvent (
 	UUID deliveryId,
-	UUID orderId
+	UUID deliveryManagerId
 ) {
-	public static AssignSuccessEvent of(UUID deliveryId, UUID orderId) {
-		return new AssignSuccessEvent(deliveryId, orderId);
+	public static AssignSuccessEvent of(UUID deliveryId, UUID deliveryManagerId) {
+		return new AssignSuccessEvent(deliveryId, deliveryManagerId);
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/DeliveryCreateEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/DeliveryCreateEvent.java
@@ -4,11 +4,10 @@ import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.comm
 import java.util.UUID;
 
 public record DeliveryCreateEvent(
-	UUID deliveryId,
-	UUID orderId
+	UUID deliveryId
 ) {
 
 	public AssignEventCommand toCommand() {
-		return new AssignEventCommand(this.deliveryId, this.orderId);
+		return new AssignEventCommand(this.deliveryId);
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/DeliveryManagerHubWriteService.java
@@ -69,7 +69,9 @@ public class DeliveryManagerHubWriteService implements DeliveryDeliveryManagerHu
 			DeliveryManagerHub manager = selectAvailableManager();
 			manager.assignDelivery(command.deliveryId());
 			deliveryMessagePort
-				.assignEventPublish(DeliveryAssignResult.success(command, manager.getName()));
+				.assignEventPublish(
+					DeliveryAssignResult
+						.success(command.deliveryId(), manager.getId(), manager.getName()));
 		} catch (BusinessException e) {
 			log.warn("DeliveryManager assignment failure : {}", e.getMessage());
 			deliveryMessagePort.assignEventPublish(DeliveryAssignResult.fail(e.getMessage()));

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/dto/commnad/AssignEventCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/dto/commnad/AssignEventCommand.java
@@ -3,8 +3,7 @@ package com.winner.client.deliveryservice.deliverymanagerhub.application.dto.com
 import java.util.UUID;
 
 public record AssignEventCommand (
-	UUID deliveryId,
-	UUID orderId
+	UUID deliveryId
 ) {
 
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/dto/result/DeliveryAssignResult.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/dto/result/DeliveryAssignResult.java
@@ -1,6 +1,5 @@
 package com.winner.client.deliveryservice.deliverymanagerhub.application.dto.result;
 
-import com.winner.client.deliveryservice.deliverymanagerhub.application.dto.commnad.AssignEventCommand;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/dto/result/DeliveryAssignResult.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/application/dto/result/DeliveryAssignResult.java
@@ -13,15 +13,15 @@ public class DeliveryAssignResult {
 	private final boolean success;
 	private final String errorMessage;
 	private final String deliveryManagerName;
+	private final UUID deliveryManagerId;
 	private final UUID deliveryId;
-	private final UUID orderId;
 
-	public static DeliveryAssignResult success(AssignEventCommand command, String deliveryManagerName) {
+	public static DeliveryAssignResult success(UUID deliveryId, UUID deliveryManagerId, String deliveryManagerName) {
 		return DeliveryAssignResult.builder()
 			.success(true)
 			.deliveryManagerName(deliveryManagerName)
-			.deliveryId(command.deliveryId())
-			.orderId(command.orderId())
+			.deliveryManagerId(deliveryManagerId)
+			.deliveryId(deliveryId)
 			.build();
 	}
 

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryMessagePortImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryMessagePortImpl.java
@@ -20,7 +20,7 @@ public class DeliveryMessagePortImpl implements DeliveryMessagePort {
 	public void assignEventPublish(DeliveryAssignResult result) {
 		if (result.isSuccess()) {
 			publisher.publishEvent(
-				AssignSuccessEvent.of(result.getDeliveryId(), result.getOrderId())
+				AssignSuccessEvent.of(result.getDeliveryId(), result.getDeliveryManagerId())
 			);
 		} else {
 			publisher.publishEvent(AssignFailEvent.from(result.getErrorMessage()));


### PR DESCRIPTION
### 📎 관련 이슈
- close #169 

### 📌 작업 내용
- 배송담당자 배정 이벤트 정보에 매니저 아이디 추가 & 주문 아이디 삭제

### ✨ 변경 사항
- 배송담당자 배정 이벤트 정보에 매니저 아이디 추가 & 주문 아이디 삭제

### 📝 리뷰 포인트 (선택)


### 🧠 기타 참고 사항
