### PR TITLE
Feat/153 add delivery completed event

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignDeliveryManagerCompanyEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignDeliveryManagerCompanyEvent.java
@@ -7,7 +7,7 @@ public record AssignDeliveryManagerCompanyEvent(
     UUID deliveryId,
     UUID toHubId
 ) {
-  public static AssignDeliveryManagerCompanyEvent of(Delivery delivery) {
+  public static AssignDeliveryManagerCompanyEvent from(Delivery delivery) {
     return new AssignDeliveryManagerCompanyEvent(
         delivery.getId(),
         delivery.getHubRoute().getDestinationHubId()

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignDeliveryManagerHubEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignDeliveryManagerHubEvent.java
@@ -1,24 +1,7 @@
 package com.winner.client.deliveryservice.common.event;
 
-import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
-import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import java.util.UUID;
 
 public record AssignDeliveryManagerHubEvent(
-    UUID deliveryId,
-    UUID deliveryRouteId
-) {
-  public static AssignDeliveryManagerHubEvent of(Delivery delivery, DeliveryRoute firstRoute) {
-    return new AssignDeliveryManagerHubEvent(
-        delivery.getId(),
-        firstRoute.getId()
-    );
-  }
-
-  public static AssignDeliveryManagerHubEvent of(DeliveryRoute firstRoute) {
-    return new AssignDeliveryManagerHubEvent(
-        firstRoute.getDelivery().getId(),
-        firstRoute.getId()
-    );
-  }
-}
+    UUID deliveryId
+) { }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompleteDeliveryCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompleteDeliveryCommand.java
@@ -1,0 +1,8 @@
+package com.winner.client.deliveryservice.delivery.application.dto.command;
+
+import java.util.UUID;
+
+public record CompleteDeliveryCommand(
+    UUID deliveryId, UUID deliveryManagerId
+) {
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompleteDeliveryRouteCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompleteDeliveryRouteCommand.java
@@ -1,0 +1,8 @@
+package com.winner.client.deliveryservice.delivery.application.dto.command;
+
+import java.util.UUID;
+
+public record CompleteDeliveryRouteCommand(
+    UUID deliveryId, UUID deliveryManagerId
+) {
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/DeliveryRouteAssignCompleteCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/DeliveryRouteAssignCompleteCommand.java
@@ -3,8 +3,7 @@ package com.winner.client.deliveryservice.delivery.application.dto.command;
 import java.util.UUID;
 
 public record DeliveryRouteAssignCompleteCommand(
-    UUID deliveryRouteId,
-    UUID orderId,
+    UUID deliveryId,
     UUID deliveryManagerId,
     String deliveryManagerName
 ) {}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/HubDeliveryManagerAssignFailCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/HubDeliveryManagerAssignFailCommand.java
@@ -4,6 +4,6 @@ import java.util.UUID;
 
 public record HubDeliveryManagerAssignFailCommand(
     String failReason,
-    UUID deliveryRouteId
+    UUID deliveryId
 ) {
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/reader/HubRouteReader.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/reader/HubRouteReader.java
@@ -1,8 +1,8 @@
-package com.winner.client.deliveryservice.delivery.application.port;
+package com.winner.client.deliveryservice.delivery.application.reader;
 
 import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
 import java.util.UUID;
 
-public interface HubRoutePort {
+public interface HubRouteReader {
   HubRouteInfo getHubRoutes(UUID fromHubId, UUID toHubId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryAssignmentService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryAssignmentService.java
@@ -1,10 +1,10 @@
 package com.winner.client.deliveryservice.delivery.application.service;
 
 import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
-import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
+import java.util.UUID;
 
 public interface DeliveryAssignmentService {
   void assignCompanyDeliveryManager(Delivery delivery);
   void assignHubDeliveryManager(Delivery delivery);
-  void retryHubDeliveryManager(DeliveryRoute failedRoute);
+  void retryHubDeliveryManager(UUID deliveryId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryMessageUsecase.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryMessageUsecase.java
@@ -1,6 +1,8 @@
 package com.winner.client.deliveryservice.delivery.application.service;
 
 import com.winner.client.deliveryservice.delivery.application.dto.command.CompanyDeliveryManagerAssignFailCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CompleteDeliveryCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CompleteDeliveryRouteCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryAssignCompleteCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.command.HubDeliveryManagerAssignFailCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryRouteAssignCompleteCommand;
@@ -10,4 +12,7 @@ public interface DeliveryMessageUsecase {
   void completeCompanyDeliveryManagerAssign(DeliveryAssignCompleteCommand command);
   void retryHubDeliveryManagerAssign(HubDeliveryManagerAssignFailCommand command);
   void retryCompanyDeliveryManagerAssign(CompanyDeliveryManagerAssignFailCommand command);
+
+  void completeDeliveryRoute(CompleteDeliveryRouteCommand command);
+  void completeDelivery(CompleteDeliveryCommand command);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryAssignmentServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryAssignmentServiceImpl.java
@@ -2,18 +2,16 @@ package com.winner.client.deliveryservice.delivery.application.service.impl;
 
 import com.winner.client.deliveryservice.common.event.AssignDeliveryManagerCompanyEvent;
 import com.winner.client.deliveryservice.common.event.AssignDeliveryManagerHubEvent;
-import com.winner.client.deliveryservice.common.exception.delivery.DeliveryErrorCode;
 import com.winner.client.deliveryservice.delivery.application.dto.command.CreateDeliveryRouteCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
 import com.winner.client.deliveryservice.delivery.application.port.DeliveryEventPort;
-import com.winner.client.deliveryservice.delivery.application.port.HubRoutePort;
+import com.winner.client.deliveryservice.delivery.application.reader.HubRouteReader;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryAssignmentService;
 import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
 import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
-import com.winner.client.global.exception.BusinessException;
-import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,37 +20,36 @@ import org.springframework.stereotype.Service;
 public class DeliveryAssignmentServiceImpl implements DeliveryAssignmentService {
 
   private final DeliveryRouteRepository deliveryRouteRepository;
-  private final HubRoutePort hubRoutePort;
+  private final HubRouteReader hubRouteReader;
   private final DeliveryEventPort deliveryEventPort;
 
   @Override
   public void assignCompanyDeliveryManager(Delivery delivery) {
-    deliveryEventPort.publishAssignCompanyEvent(AssignDeliveryManagerCompanyEvent.of(delivery));
+    deliveryEventPort.publishAssignCompanyEvent(AssignDeliveryManagerCompanyEvent.from(delivery));
   }
 
   @Override
   public void assignHubDeliveryManager(Delivery delivery) {
-    List<DeliveryRoute> routes = createAndSaveHubRoutes(delivery);
-
-    DeliveryRoute firstRoute = getFirstRoute(routes);
-
-    deliveryEventPort.publishAssignHubEvent(AssignDeliveryManagerHubEvent.of(delivery, firstRoute));
+    createAndSaveHubRoutes(delivery);
+    publishHubAssignEvent(delivery.getId());
   }
 
   @Override
-  public void retryHubDeliveryManager(DeliveryRoute failedRoute) {
-    deliveryEventPort.publishAssignHubEvent(
-        AssignDeliveryManagerHubEvent.of(failedRoute));
+  public void retryHubDeliveryManager(UUID deliveryId) {
+    publishHubAssignEvent(deliveryId);
   }
 
-  private List<DeliveryRoute> createAndSaveHubRoutes(Delivery delivery) {
+  private void publishHubAssignEvent(UUID deliveryId) {
+    deliveryEventPort.publishAssignHubEvent(new AssignDeliveryManagerHubEvent(deliveryId));
+  }
+
+  private void createAndSaveHubRoutes(Delivery delivery) {
     List<DeliveryRoute> routes = getDeliveryHubRoute(delivery);
     routes.forEach(deliveryRouteRepository::save);
-    return routes;
   }
 
   private List<DeliveryRoute> getDeliveryHubRoute(Delivery delivery) {
-    HubRouteInfo hubRouteInfo = hubRoutePort.
+    HubRouteInfo hubRouteInfo = hubRouteReader.
         getHubRoutes(delivery.getHubRoute().getOriginHubId(), delivery.getHubRoute().getDestinationHubId());
 
     return CreateDeliveryRouteCommand.of(delivery, hubRouteInfo)
@@ -61,9 +58,4 @@ public class DeliveryAssignmentServiceImpl implements DeliveryAssignmentService 
         .toList();
   }
 
-  private DeliveryRoute getFirstRoute(List<DeliveryRoute> routes) {
-    return routes.stream()
-        .min(Comparator.comparingInt(DeliveryRoute::getSeq))
-        .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY_ROUTE));
-  }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryMessageServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryMessageServiceImpl.java
@@ -2,16 +2,19 @@ package com.winner.client.deliveryservice.delivery.application.service.impl;
 
 import com.winner.client.deliveryservice.common.exception.delivery.DeliveryErrorCode;
 import com.winner.client.deliveryservice.delivery.application.dto.command.CompanyDeliveryManagerAssignFailCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CompleteDeliveryCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CompleteDeliveryRouteCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryAssignCompleteCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryRouteAssignCompleteCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.command.HubDeliveryManagerAssignFailCommand;
-import com.winner.client.deliveryservice.delivery.application.service.DeliveryMessageUsecase;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryAssignmentService;
+import com.winner.client.deliveryservice.delivery.application.service.DeliveryMessageUsecase;
 import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
 import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRepository;
 import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
 import com.winner.client.global.exception.BusinessException;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,8 +31,16 @@ public class DeliveryMessageServiceImpl implements DeliveryMessageUsecase {
   @Override
   @Transactional
   public void completeHubDeliveryManagerAssign(DeliveryRouteAssignCompleteCommand command) {
-    DeliveryRoute route = findDeliveryRouteById(command.deliveryRouteId());
+    DeliveryRoute route = deliveryRouteRepository.findFirstPendingRoute(command.deliveryId())
+        .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY_ROUTE));
+
     route.updateDeliveryManagerInfo(command.deliveryManagerId(), command.deliveryManagerName());
+    route.startProgress(); // PENDING → IN_PROGRESS
+
+    if (route.isFirstRoute()) {
+      Delivery delivery = route.getDelivery();
+      delivery.startHubMoving();
+    }
     // todo: order 배송 담당자 정보 update
   }
 
@@ -39,32 +50,50 @@ public class DeliveryMessageServiceImpl implements DeliveryMessageUsecase {
     Delivery delivery = findDeliveryById(command.deliveryId());
 
     delivery.updateDeliveryManagerInfo(command.deliveryManagerId(), command.deliveryManagerName());
+    delivery.startVendorMoving();
     // todo: order 배송 담당자 정보 update
   }
 
   @Override
-  public void retryHubDeliveryManagerAssign(HubDeliveryManagerAssignFailCommand command) {
-    DeliveryRoute failedRoute = findDeliveryRouteById(command.deliveryRouteId());
+  @Transactional
+  public void completeDeliveryRoute(CompleteDeliveryRouteCommand command) {
+    DeliveryRoute route = deliveryRouteRepository.findFirstInProgressRoute(command.deliveryId())
+        .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY_ROUTE));
 
-    deliveryAssignmentService.retryHubDeliveryManager(failedRoute);
+    route.complete();
+
+    Optional<DeliveryRoute> nextPending = deliveryRouteRepository.findFirstPendingRoute(command.deliveryId());
+
+    if (nextPending.isPresent()) {
+      deliveryAssignmentService.retryHubDeliveryManager(command.deliveryId());
+    } else {
+      Delivery delivery = route.getDelivery();
+      deliveryAssignmentService.assignCompanyDeliveryManager(delivery);
+    }
+  }
+
+  @Override
+  @Transactional
+  public void completeDelivery(CompleteDeliveryCommand command) {
+    Delivery delivery = findDeliveryById(command.deliveryId());
+    delivery.complete();
+    // todo: order 배송 완료 status update
+  }
+
+  @Override
+  public void retryHubDeliveryManagerAssign(HubDeliveryManagerAssignFailCommand command) {
+    deliveryAssignmentService.retryHubDeliveryManager(command.deliveryId());
   }
 
   @Override
   public void retryCompanyDeliveryManagerAssign(CompanyDeliveryManagerAssignFailCommand command) {
     Delivery delivery = findDeliveryById(command.deliveryId());
-
     deliveryAssignmentService.assignCompanyDeliveryManager(delivery);
   }
 
   private Delivery findDeliveryById(UUID deliveryId) {
     return deliveryRepository.findById(deliveryId)
         .orElseThrow(()-> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY));
-  }
-
-  private DeliveryRoute findDeliveryRouteById(UUID deliveryId) {
-    return deliveryRouteRepository.findById(deliveryId)
-        .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY_ROUTE));
-
   }
 
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/DeliveryRoute.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/DeliveryRoute.java
@@ -94,6 +94,10 @@ public class DeliveryRoute {
     }
   }
 
+  public boolean isFirstRoute() {
+    return this.seq == 1;
+  }
+
   private void changeStatus(DeliveryRouteStatus next) {
     if (!this.status.canTransitionTo(next)) {
 

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRouteRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRouteRepository.java
@@ -8,5 +8,7 @@ import java.util.UUID;
 public interface DeliveryRouteRepository {
   List<DeliveryRoute> findAllByDeliveryId(UUID deliveryId);
   Optional<DeliveryRoute> findById(UUID id);
+  Optional<DeliveryRoute> findFirstPendingRoute(UUID deliveryId);
+  Optional<DeliveryRoute> findFirstInProgressRoute(UUID deliveryId);
   void save(DeliveryRoute route);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/HubClientAdapter.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/HubClientAdapter.java
@@ -1,7 +1,7 @@
 package com.winner.client.deliveryservice.delivery.infrastructure.client;
 
 import com.winner.client.deliveryservice.delivery.application.dto.external.HubRouteInfo;
-import com.winner.client.deliveryservice.delivery.application.port.HubRoutePort;
+import com.winner.client.deliveryservice.delivery.application.reader.HubRouteReader;
 import com.winner.client.deliveryservice.delivery.infrastructure.client.dto.HubRouteResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class HubClientAdapter implements HubRoutePort {
+public class HubClientAdapter implements HubRouteReader {
 
   private final HubClient hubClient;
 

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
@@ -24,6 +24,16 @@ public class DeliveryRouteJpaRepository implements DeliveryRouteRepository {
   }
 
   @Override
+  public Optional<DeliveryRoute> findFirstPendingRoute(UUID deliveryId) {
+    return routeJpaRepository.findFirstPendingRoute(deliveryId);
+  }
+
+  @Override
+  public Optional<DeliveryRoute> findFirstInProgressRoute(UUID deliveryId) {
+    return routeJpaRepository.findFirstInProgressRoute(deliveryId);
+  }
+
+  @Override
   public void save(DeliveryRoute route) {
     routeJpaRepository.save(route);
   }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRouteRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRouteRepository.java
@@ -2,9 +2,31 @@ package com.winner.client.deliveryservice.delivery.infrastructure.repository;
 
 import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SpringDataDeliveryRouteRepository extends JpaRepository<DeliveryRoute, UUID> {
   List<DeliveryRoute> findAllByDeliveryId(UUID deliveryId);
+
+  @Query("""
+    SELECT dr FROM DeliveryRoute dr
+    WHERE dr.delivery.id = :deliveryId
+    AND dr.status = 'PENDING'
+    ORDER BY dr.seq ASC
+    LIMIT 1
+    """)
+  Optional<DeliveryRoute> findFirstPendingRoute(@Param("deliveryId") UUID deliveryId);
+
+  @Query("""
+    SELECT dr FROM DeliveryRoute dr
+    WHERE dr.delivery.id = :deliveryId
+    AND dr.status = 'IN_PROGRESS'
+    ORDER BY dr.seq ASC
+    LIMIT 1
+    """)
+  Optional<DeliveryRoute> findFirstInProgressRoute(@Param("deliveryId") UUID deliveryId);
+
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #153

### 📌 작업 내용
- 허브/업체 배송 담당자 완료 이벤트 처리 로직 추가
- 허브 배송 담당자 식별자를 routeId -> deliveryId로 변경

### ✨ 변경 사항
**[허브 배송 담당자 식별자를 routeId -> deliveryId로 변경]**
```
deliveryId 기준으로 PENDING 상태인 가장 작은 seq 경로 조회
        ↓
있으면 → Hub 담당자 배정 이벤트 발행
없으면 → 모든 경로 완료 → Company 담당자 배정
        ↓
성공 → 해당 route 담당자 세팅 → 다시 deliveryId로 다음 PENDING 조회
실패 → deliveryId로 재요청
```

`completeDeliveryRoute`
- 진행 중인 경로를 찾아 완료 상태로 update 후 
- **대기 중인 경로가 있으면** 허브 담당자를 배정 이벤트를 발행하고 모든 경로
- **대기 중인 경로가 없으면** 업체 담당자를 배정

`completeDelivery`
- 배송 상태를 완료로 update (주문 상태 update 추가 예정)

### 📝 리뷰 포인트 (선택)
- 리팩토링이 적절한지
- 완료 처리가 적절한지

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)