### PR TITLE
[refactor] 허브 삭제 시 사용자 소속 해제 로직을 referenceId 기반으로 변경

### DIFF
--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
@@ -77,8 +77,7 @@ public class HubService {
         Hub hub = hubRepository.findByIdAndDeletedAtIsNull(hubId)
             .orElseThrow(()-> new HubException(HubErrorCode.HUB_NOT_FOUND));
 
-        // TODO: 허브에 속한 사용자 목록 조회 후 전체 unassign 처리 필요
-        userPort.unassignUser(userId);
+        userPort.unassignUsersByReferenceId(hubId);
 
         hub.delete(userId);
 

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/port/UserPort.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/port/UserPort.java
@@ -4,5 +4,5 @@ import java.util.UUID;
 
 public interface UserPort {
 
-    void unassignUser(UUID userId);
+    void unassignUsersByReferenceId(UUID referenceId);
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/client/UserClient.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/client/UserClient.java
@@ -8,6 +8,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 @FeignClient(name="user-service")
 public interface UserClient {
 
-    @PatchMapping("/internal/v1/users/{userId}/unassign")
-    void unassignUser(@PathVariable UUID userId);
+    @PatchMapping("/internal/v1/users/unassign/{referenceId}")
+    void unassignUsersByReferenceId(@PathVariable UUID referenceId);
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/client/UserClientAdapter.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/infrastructure/client/UserClientAdapter.java
@@ -12,7 +12,7 @@ public class UserClientAdapter implements UserPort {
     private final UserClient userClient;
 
     @Override
-    public void unassignUser(UUID userId) {
-        userClient.unassignUser(userId);
+    public void unassignUsersByReferenceId(UUID referenceId) {
+        userClient.unassignUsersByReferenceId(referenceId);
     }
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #174

### 📌 작업 내용
- 허브 삭제 시 사용자 소속 해제 로직을 userId 기반에서 referenceId(hubId) 기반으로 변경
- user-service에서 해당 허브 소속 사용자 전체를 처리하도록 구조 개선

### ✨ 변경 사항
- UserPort 인터페이스 메서드 변경
  - unassignUser → unassignUsersByReferenceId
- UserClient (Feign) API 변경
  - /internal/v1/users/unassign/{referenceId}
- UserClientAdapter 수정
- HubService에서 referenceId(hubId) 기반으로 호출하도록 수정

### 📝 리뷰 포인트
- 서비스 간 책임 분리 (hub → user) 방향이 적절한지
- referenceId(hubId)를 그대로 전달하는 방식이 괜찮은지

### 🧠 기타 참고 사항
- hubId와 referenceId는 현재 동일한 값으로 사용
- user-service에서 해당 허브 소속 사용자 전체 처리