### PR TITLE
[feat] 업체/허브 배송 담당자 이벤트에 따른 주문 정보 업데이트

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignDeliveryManagerCompanyEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/AssignDeliveryManagerCompanyEvent.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 public record AssignDeliveryManagerCompanyEvent(
     UUID deliveryId,
-    UUID toHubId
+    UUID hubId
 ) {
   public static AssignDeliveryManagerCompanyEvent from(Delivery delivery) {
     return new AssignDeliveryManagerCompanyEvent(

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/port/OrderPort.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/port/OrderPort.java
@@ -1,0 +1,8 @@
+package com.winner.client.deliveryservice.delivery.application.port;
+
+import java.util.UUID;
+
+public interface OrderPort {
+  void updateOrderDeliveryInfo(UUID deliveryId, UUID deliveryManagerId, String deliveryStatus);
+  void updateOrderDeliveryCompleted(UUID deliveryId);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryCommandService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryCommandService.java
@@ -7,8 +7,6 @@ import java.util.UUID;
 
 public interface DeliveryCommandService {
   CreateDeliveryResult createDelivery(CreateDeliveryCommand command);
-  DeliveryCommandResponse startHubWaiting(
-      UUID deliveryId, String userRole, UUID referenceId);
   DeliveryCommandResponse startHubMoving(
       UUID deliveryId, String userRole, UUID referenceId);
   DeliveryCommandResponse startVendorMoving(

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryCommandServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryCommandServiceImpl.java
@@ -44,15 +44,6 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
   }
 
   @Override
-  public DeliveryCommandResponse startHubWaiting(
-      UUID deliveryId, String userRole, UUID referenceId) {
-    Delivery delivery = findById(deliveryId);
-    validator.validateHubAdminAccess(delivery, userRole, referenceId);
-    delivery.startHubWaiting();
-    return DeliveryCommandResponse.from(delivery);
-  }
-
-  @Override
   public DeliveryCommandResponse startHubMoving(
       UUID deliveryId, String userRole, UUID referenceId) {
     Delivery delivery = findById(deliveryId);

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryMessageServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryMessageServiceImpl.java
@@ -7,6 +7,7 @@ import com.winner.client.deliveryservice.delivery.application.dto.command.Comple
 import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryAssignCompleteCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryRouteAssignCompleteCommand;
 import com.winner.client.deliveryservice.delivery.application.dto.command.HubDeliveryManagerAssignFailCommand;
+import com.winner.client.deliveryservice.delivery.application.port.OrderPort;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryAssignmentService;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryMessageUsecase;
 import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
@@ -27,6 +28,7 @@ public class DeliveryMessageServiceImpl implements DeliveryMessageUsecase {
   private final DeliveryRepository deliveryRepository;
   private final DeliveryRouteRepository deliveryRouteRepository;
   private final DeliveryAssignmentService deliveryAssignmentService;
+  private final OrderPort orderPort;
 
   @Override
   @Transactional
@@ -35,13 +37,19 @@ public class DeliveryMessageServiceImpl implements DeliveryMessageUsecase {
         .orElseThrow(() -> new BusinessException(DeliveryErrorCode.NOT_FOUND_DELIVERY_ROUTE));
 
     route.updateDeliveryManagerInfo(command.deliveryManagerId(), command.deliveryManagerName());
-    route.startProgress(); // PENDING → IN_PROGRESS
+    route.startProgress();
+
+    Delivery delivery = route.getDelivery();
 
     if (route.isFirstRoute()) {
-      Delivery delivery = route.getDelivery();
       delivery.startHubMoving();
     }
-    // todo: order 배송 담당자 정보 update
+
+    orderPort.updateOrderDeliveryInfo(
+        command.deliveryId(),
+        command.deliveryManagerId(),
+        delivery.getStatus().name()
+    );
   }
 
   @Override
@@ -51,7 +59,12 @@ public class DeliveryMessageServiceImpl implements DeliveryMessageUsecase {
 
     delivery.updateDeliveryManagerInfo(command.deliveryManagerId(), command.deliveryManagerName());
     delivery.startVendorMoving();
-    // todo: order 배송 담당자 정보 update
+
+    orderPort.updateOrderDeliveryInfo(
+        command.deliveryId(),
+        command.deliveryManagerId(),
+        delivery.getStatus().name()
+    );
   }
 
   @Override
@@ -77,7 +90,8 @@ public class DeliveryMessageServiceImpl implements DeliveryMessageUsecase {
   public void completeDelivery(CompleteDeliveryCommand command) {
     Delivery delivery = findDeliveryById(command.deliveryId());
     delivery.complete();
-    // todo: order 배송 완료 status update
+
+    orderPort.updateOrderDeliveryCompleted(command.deliveryId());
   }
 
   @Override

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/Delivery.java
@@ -96,10 +96,6 @@ public class Delivery extends BaseAuditEntity {
         .allMatch(route -> route.getStatus() == DeliveryRouteStatus.COMPLETED);
   }
 
-  public void startHubWaiting() {
-    changeStatus(DeliveryStatus.HUB_WAITING);
-  }
-
   public void startHubMoving() {
     changeStatus(DeliveryStatus.HUB_MOVING);
   }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/enums/DeliveryStatus.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/enums/DeliveryStatus.java
@@ -6,12 +6,7 @@ public enum DeliveryStatus {
 
   PENDING {
     public Set<DeliveryStatus> nextStates() {
-      return Set.of(HUB_WAITING, CANCELLED);
-    }
-  },
-  HUB_WAITING {
-    public Set<DeliveryStatus> nextStates() {
-      return Set.of(HUB_MOVING, CANCELLED);
+      return Set.of(CANCELLED);
     }
   },
   HUB_MOVING {

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/HubClientAdapter.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/HubClientAdapter.java
@@ -16,6 +16,6 @@ public class HubClientAdapter implements HubRouteReader {
   @Override
   public HubRouteInfo getHubRoutes(UUID fromHubId, UUID toHubId) {
     HubRouteResponse response = hubClient.getHubRoutes(fromHubId, toHubId);
-    return HubRouteInfo.from(response); // ← 여기서 변환
+    return HubRouteInfo.from(response);
   }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/OrderClient.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/OrderClient.java
@@ -1,0 +1,17 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.client;
+
+import com.winner.client.deliveryservice.delivery.infrastructure.client.dto.UpdateOrderInfoRequest;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name="order-service")
+public interface OrderClient {
+  @PatchMapping("/internal/v1/orders}")
+  void updateOrderInfo(@RequestBody UpdateOrderInfoRequest request);
+
+  @PatchMapping("/internal/v1/orders")
+  void updateDeliveryCompleted(@RequestParam UUID deliveryId);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/OrderClientAdapter.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/OrderClientAdapter.java
@@ -1,0 +1,26 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.client;
+
+import com.winner.client.deliveryservice.delivery.application.port.OrderPort;
+import com.winner.client.deliveryservice.delivery.infrastructure.client.dto.UpdateOrderInfoRequest;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderClientAdapter implements OrderPort {
+
+  private final OrderClient orderClient;
+
+  @Override
+  public void updateOrderDeliveryInfo(UUID deliveryId, UUID deliveryManagerId, String deliveryStatus) {
+    orderClient.updateOrderInfo(
+        new UpdateOrderInfoRequest(deliveryId, deliveryManagerId, deliveryStatus)
+    );
+  }
+
+  @Override
+  public void updateOrderDeliveryCompleted(UUID deliveryId) {
+    orderClient.updateDeliveryCompleted(deliveryId);
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/dto/UpdateOrderInfoRequest.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/dto/UpdateOrderInfoRequest.java
@@ -1,0 +1,8 @@
+package com.winner.client.deliveryservice.delivery.infrastructure.client.dto;
+
+import java.util.UUID;
+
+public record UpdateOrderInfoRequest(
+    UUID delivery, UUID deliveryManagerId, String deliveryStatus
+) {
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRouteRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRouteRepository.java
@@ -13,7 +13,8 @@ public interface SpringDataDeliveryRouteRepository extends JpaRepository<Deliver
 
   @Query("""
     SELECT dr FROM DeliveryRoute dr
-    WHERE dr.delivery.id = :deliveryId
+    JOIN FETCH dr.delivery d
+    WHERE d.id = :deliveryId
     AND dr.status = 'PENDING'
     ORDER BY dr.seq ASC
     LIMIT 1

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/DeliveryController.java
@@ -66,18 +66,6 @@ public class DeliveryController {
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
   }
 
-  @PatchMapping("/{deliveryId}/hub-waiting")
-  public ResponseEntity<ApiResponse<DeliveryCommandResponse>> startHubWaiting(
-      @PathVariable UUID deliveryId,
-      @RequestHeader("X-User-Role") String userRole,
-      @RequestHeader("X-Reference-Id") UUID referenceId
-  ){
-    DeliveryCommandResponse response =
-        deliveryCommandService.startHubWaiting(deliveryId, userRole, referenceId);
-    return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
-        .body(ApiResponse.success(CommonSuccessCode.OK, response));
-  }
-
   @PatchMapping("/{deliveryId}/hub-moving")
   public ResponseEntity<ApiResponse<DeliveryCommandResponse>> startHubMoving(
       @PathVariable UUID deliveryId,


### PR DESCRIPTION
### 📎 관련 이슈
- close #177 

### 📌 작업 내용
- 허브/업체 배송 담당자 배정 이벤트 수신 시, 배송에서 주문 정보 업데이트 로직 추가
- 배송 담당자 배정 시 주문의 배송 담당자 ID 및 상태 동기화
- 업체 배송 완료 시 주문 상태를 배송 완료로 변경하도록 처리

### ✨ 변경 사항
* `@PatchMapping("/internal/v1/orders}") updateOrderInfo() `
1. **허브 배송 담당자 배정 후** 
    주문 정보 update 요청 Body에 배송 ID, 배송 담당자 ID 및 HUB_MOVING 상태 전달
2. **업체 배송 담당자 배정 후** 
    주문 정보 update 요청 Body에 배송 ID, 배송 담당자 ID 및 FOR_VENDOR_MOVING 상태 전달

* 업체 배송 완료 시 updateDeliveryCompleted 요청을 통해 주문 상태를 배송 완료로 변경하도록 처리

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)