### PR TITLE
[feat]: 업체 배송 담당자 배정 기능 추가

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/deliverymanager/company/AssignCompanyDeliveryManagerFailEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/deliverymanager/company/AssignCompanyDeliveryManagerFailEvent.java
@@ -1,0 +1,16 @@
+package com.winner.client.deliveryservice.common.event.deliverymanager.company;
+
+import com.winner.client.deliveryservice.deliverymanagercompany.application.dto.re.CompanyDeliveryManagerAssignResult;
+import java.util.UUID;
+
+public record AssignCompanyDeliveryManagerFailEvent(
+	String message,
+	UUID deliveryId
+) {
+	public static AssignCompanyDeliveryManagerFailEvent from(CompanyDeliveryManagerAssignResult result) {
+		return new AssignCompanyDeliveryManagerFailEvent(
+			result.getErrorMessage(),
+			result.getDeliveryId()
+		);
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/deliverymanager/company/AssignCompanyDeliveryManagerSuccessEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/deliverymanager/company/AssignCompanyDeliveryManagerSuccessEvent.java
@@ -1,0 +1,18 @@
+package com.winner.client.deliveryservice.common.event.deliverymanager.company;
+
+import com.winner.client.deliveryservice.deliverymanagercompany.application.dto.re.CompanyDeliveryManagerAssignResult;
+import java.util.UUID;
+
+public record AssignCompanyDeliveryManagerSuccessEvent(
+	UUID deliveryId,
+	UUID deliveryManagerId,
+	String name
+) {
+	public static AssignCompanyDeliveryManagerSuccessEvent from(CompanyDeliveryManagerAssignResult result) {
+		return new AssignCompanyDeliveryManagerSuccessEvent(
+			result.getDeliveryId(),
+			result.getDeliveryManagerId(),
+			result.getDeliveryManagerName()
+		);
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/company/DeliveryManagerCompanyErrorCode.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/deliverymanager/company/DeliveryManagerCompanyErrorCode.java
@@ -21,7 +21,9 @@ public enum DeliveryManagerCompanyErrorCode implements ErrorCode {
 	USER_NAME_CANNOT_BE_NULL("ERROR_606", HttpStatus.BAD_REQUEST,
 		"유저 이름은 null 일 수 없습니다."),
 	NOT_AVAILABLE("ERROR_607", HttpStatus.CONFLICT,
-		"배송 가능상태가 아닙니다.")
+		"배송 가능상태가 아닙니다."),
+	NOT_FOUND_AVAILABLE_COMPANY_DELIVERY_MANAGER("ERROR_608", HttpStatus.NOT_FOUND,
+		"배정 가능한 업체 배송담당자를 찾을 수 없습니다.")
 	;
 
 	private final String code;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/DeliveryManagerCompanyWriteService.java
@@ -1,24 +1,32 @@
 package com.winner.client.deliveryservice.deliverymanagercompany.application;
 
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.ALREADY_REGISTERED_COMPANY_DELIVERY_MANAGER;
+import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.NOT_FOUND_AVAILABLE_COMPANY_DELIVERY_MANAGER;
 import static com.winner.client.deliveryservice.common.exception.deliverymanager.company.DeliveryManagerCompanyErrorCode.NOT_FOUND_COMPANY_DELIVERY_MANAGER;
 
+import com.winner.client.deliveryservice.deliverymanagercompany.application.dto.command.DeliveryManagerAssignEventCommand;
 import com.winner.client.deliveryservice.deliverymanagercompany.application.dto.command.DeliveryManagerCompanyRegistrationCommand;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.dto.re.CompanyDeliveryManagerAssignResult;
 import com.winner.client.deliveryservice.deliverymanagercompany.application.dto.result.DeliveryManagerCompanyInfoResult;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.message.CompanyDeliveryManagerExternalPort;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.message.DeliveryDeliveryManagerCompanyUsecase;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.entity.DeliveryManagerCompany;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.repository.DeliveryManagerCompanyRepository;
 import com.winner.client.global.exception.BusinessException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class DeliveryManagerCompanyWriteService {
+@Slf4j
+public class DeliveryManagerCompanyWriteService implements DeliveryDeliveryManagerCompanyUsecase {
 
 	private final DeliveryManagerCompanyRepository repository;
+	private final CompanyDeliveryManagerExternalPort companyDeliveryManagerExternalPort;
 
 	public DeliveryManagerCompanyInfoResult registration(
 		DeliveryManagerCompanyRegistrationCommand command) {
@@ -51,5 +59,31 @@ public class DeliveryManagerCompanyWriteService {
 		DeliveryManagerCompany deliveryManagerCompany = repository.findByUserIdAndDeletedByNull(userId)
 			.orElseThrow(() -> new BusinessException(NOT_FOUND_COMPANY_DELIVERY_MANAGER));
 		deliveryManagerCompany.softDelete(userId);
+	}
+
+	@Override
+	public void assignHubDeliveryManager(DeliveryManagerAssignEventCommand command) {
+		try {
+			DeliveryManagerCompany manager = selectAvailableManager(command.hubId());
+			manager.assignDelivery(command.deliveryId());
+			companyDeliveryManagerExternalPort
+				.assignEventPublish(
+					CompanyDeliveryManagerAssignResult.success(
+						command.deliveryId(),
+						manager.getId(),
+						manager.getName()
+					));
+		} catch (BusinessException e) {
+			log.warn("DeliveryManager assignment failure : {}", e.getMessage());
+			companyDeliveryManagerExternalPort
+				.assignEventPublish(CompanyDeliveryManagerAssignResult.fail(e.getMessage()));
+		}
+	}
+
+	private DeliveryManagerCompany selectAvailableManager(UUID hubId) {
+		return repository.findAllAvailableManagers(hubId)
+			.stream()
+			.findFirst()
+			.orElseThrow(() -> new BusinessException(NOT_FOUND_AVAILABLE_COMPANY_DELIVERY_MANAGER));
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/dto/command/DeliveryManagerAssignEventCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/dto/command/DeliveryManagerAssignEventCommand.java
@@ -1,0 +1,12 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.application.dto.command;
+
+import java.util.UUID;
+
+public record DeliveryManagerAssignEventCommand(
+	UUID deliveryId,
+	UUID hubId
+) {
+	public static DeliveryManagerAssignEventCommand of(UUID deliveryId, UUID hubId) {
+		return new DeliveryManagerAssignEventCommand(deliveryId, hubId);
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/dto/re/CompanyDeliveryManagerAssignResult.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/dto/re/CompanyDeliveryManagerAssignResult.java
@@ -1,0 +1,33 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.application.dto.re;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(access = lombok.AccessLevel.PRIVATE)
+public class CompanyDeliveryManagerAssignResult {
+
+	private final boolean success;
+	private final String errorMessage;
+	private final String deliveryManagerName;
+	private final UUID deliveryManagerId;
+	private final UUID deliveryId;
+
+	public static CompanyDeliveryManagerAssignResult success(UUID deliveryId, UUID deliveryManagerId, String deliveryManagerName) {
+		return CompanyDeliveryManagerAssignResult.builder()
+			.success(true)
+			.deliveryManagerName(deliveryManagerName)
+			.deliveryManagerId(deliveryManagerId)
+			.deliveryId(deliveryId)
+			.build();
+	}
+
+	public static CompanyDeliveryManagerAssignResult fail(String errorMessage) {
+		return CompanyDeliveryManagerAssignResult.builder()
+			.success(false)
+			.errorMessage(errorMessage)
+			.build();
+	}
+
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/message/CompanyDeliveryManagerExternalPort.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/message/CompanyDeliveryManagerExternalPort.java
@@ -1,0 +1,7 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.application.message;
+
+import com.winner.client.deliveryservice.deliverymanagercompany.application.dto.re.CompanyDeliveryManagerAssignResult;
+
+public interface CompanyDeliveryManagerExternalPort {
+	void assignEventPublish(CompanyDeliveryManagerAssignResult result);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/message/DeliveryDeliveryManagerCompanyUsecase.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/application/message/DeliveryDeliveryManagerCompanyUsecase.java
@@ -1,0 +1,7 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.application.message;
+
+import com.winner.client.deliveryservice.deliverymanagercompany.application.dto.command.DeliveryManagerAssignEventCommand;
+
+public interface DeliveryDeliveryManagerCompanyUsecase {
+	void assignHubDeliveryManager(DeliveryManagerAssignEventCommand command);
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/entity/DeliveryManagerCompany.java
@@ -75,6 +75,7 @@ public class DeliveryManagerCompany extends BaseAuditEntity {
 		if (!this.deliveryManagerStatus.isAvailable()) {
 			throw new BusinessException(NOT_AVAILABLE);
 		}
+		this.deliveryId = new DeliveryId(deliveryId);
 		this.deliveryManagerStatus = DeliveryManagerStatus.IN_DELIVERY;
 	}
 

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/repository/DeliveryManagerCompanyRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/domain/repository/DeliveryManagerCompanyRepository.java
@@ -1,6 +1,7 @@
 package com.winner.client.deliveryservice.deliverymanagercompany.domain.repository;
 
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.entity.DeliveryManagerCompany;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +12,5 @@ public interface DeliveryManagerCompanyRepository {
 	Optional<DeliveryManagerCompany> findLastAssignmentOrderByHubId(UUID hubId);
 	Long countByHubId(UUID hubId);
 	Optional<DeliveryManagerCompany> findByUserIdAndDeletedByNull(UUID userId);
+	List<DeliveryManagerCompany> findAllAvailableManagers(UUID hubId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/message/CompanyDeliveryManagerExternalPortImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/message/CompanyDeliveryManagerExternalPortImpl.java
@@ -1,0 +1,27 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.infrastructure.message;
+
+import com.winner.client.deliveryservice.common.event.deliverymanager.company.AssignCompanyDeliveryManagerFailEvent;
+import com.winner.client.deliveryservice.common.event.deliverymanager.company.AssignCompanyDeliveryManagerSuccessEvent;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.dto.re.CompanyDeliveryManagerAssignResult;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.message.CompanyDeliveryManagerExternalPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CompanyDeliveryManagerExternalPortImpl implements CompanyDeliveryManagerExternalPort {
+
+	private final ApplicationEventPublisher publisher;
+
+	@Override
+	public void assignEventPublish(CompanyDeliveryManagerAssignResult result) {
+		if (result.isSuccess()) {
+			publisher.publishEvent(
+				AssignCompanyDeliveryManagerSuccessEvent.from(result));
+		} else {
+			publisher.publishEvent(
+				AssignCompanyDeliveryManagerFailEvent.from(result));
+		}
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/message/DeliveryManagerCompanySpringEventListener.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/message/DeliveryManagerCompanySpringEventListener.java
@@ -1,0 +1,21 @@
+package com.winner.client.deliveryservice.deliverymanagercompany.infrastructure.message;
+
+import com.winner.client.deliveryservice.common.event.AssignDeliveryManagerCompanyEvent;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.dto.command.DeliveryManagerAssignEventCommand;
+import com.winner.client.deliveryservice.deliverymanagercompany.application.message.DeliveryDeliveryManagerCompanyUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryManagerCompanySpringEventListener {
+
+	private final DeliveryDeliveryManagerCompanyUsecase usecase;
+
+	@EventListener
+	public void assignDeliveryManagerCompany(AssignDeliveryManagerCompanyEvent event) {
+		usecase.assignHubDeliveryManager(
+			DeliveryManagerAssignEventCommand.of(event.deliveryId(), event.toHubId()));
+	}
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/repositroy/DeliveryManagerCompanyJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/repositroy/DeliveryManagerCompanyJpaRepository.java
@@ -1,7 +1,11 @@
 package com.winner.client.deliveryservice.deliverymanagercompany.infrastructure.repositroy;
 
+import static com.winner.client.deliveryservice.common.constants.DeliveryManagerStatus.AVAILABLE;
+
+import com.winner.client.deliveryservice.common.constants.DeliveryManagerStatus;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.entity.DeliveryManagerCompany;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.repository.DeliveryManagerCompanyRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +41,11 @@ public class DeliveryManagerCompanyJpaRepository implements
 	@Override
 	public Optional<DeliveryManagerCompany> findByUserIdAndDeletedByNull(UUID userId) {
 		return jpaRepository.findByUser_UserIdAndDeletedByNull(userId);
+	}
+
+	@Override
+	public List<DeliveryManagerCompany> findAllAvailableManagers(UUID hubId) {
+		return jpaRepository
+			.findAllByHubId_ValueAndDeletedByNullAndDeliveryManagerStatus(hubId, AVAILABLE);
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/repositroy/DeliveryManagerCompanyJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/repositroy/DeliveryManagerCompanyJpaRepository.java
@@ -2,7 +2,6 @@ package com.winner.client.deliveryservice.deliverymanagercompany.infrastructure.
 
 import static com.winner.client.deliveryservice.common.constants.DeliveryManagerStatus.AVAILABLE;
 
-import com.winner.client.deliveryservice.common.constants.DeliveryManagerStatus;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.entity.DeliveryManagerCompany;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.repository.DeliveryManagerCompanyRepository;
 import java.util.List;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/repositroy/SpringDataDeliveryManagerRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/repositroy/SpringDataDeliveryManagerRepository.java
@@ -1,6 +1,8 @@
 package com.winner.client.deliveryservice.deliverymanagercompany.infrastructure.repositroy;
 
+import com.winner.client.deliveryservice.common.constants.DeliveryManagerStatus;
 import com.winner.client.deliveryservice.deliverymanagercompany.domain.entity.DeliveryManagerCompany;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +15,5 @@ public interface SpringDataDeliveryManagerRepository
 	boolean existsByUser_UserId(UUID userId);
 	Long countByHubId_ValueAndDeletedByIsNull(UUID hubId);
 	Optional<DeliveryManagerCompany> findByUser_UserIdAndDeletedByNull(UUID userId);
+	List<DeliveryManagerCompany> findAllByHubId_ValueAndDeletedByNullAndDeliveryManagerStatus(UUID hubId, DeliveryManagerStatus status);
 }


### PR DESCRIPTION
### 📎 관련 이슈
- #168 

### 📌 작업 내용
- 업체 배송 담당자 배정 흐름 추가
- 배송 담당자 배정 시 상태 변경과 deliveryId 설정 로직을 반영했습니다.
- 배정 가능한 허브 배송 담당자를 조회하는 메서드를 추가했습니다.
- 배정 성공/실패 결과를 담는 DTO와 이벤트 발행용 포트를 추가했습니다.
- 허브 배정 이벤트를 수신하고 처리하는 리스너 및 외부 포트 구현을 추가했습니다.

### ✨ 변경 사항
- `DeliveryDeliveryManagerCompanyUsecase` 인터페이스 추가
- `CompanyDeliveryManagerExternalPort` 인터페이스 및 구현 추가
- `CompanyDeliveryManagerAssignResult` DTO 추가
- 배송 담당자 배정 시 상태를 `IN_DELIVERY`로 변경하고 `deliveryId` 저장
- `findAllAvailableManagers` 추가
- 사용 불가한 업체 배송 담당자에 대한 에러 코드 추가
- 배정 이벤트 발행 및 수신 처리 로직 추가

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항