### PR TITLE
[Feat] 유저 목록 조회 API 작성

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -3,8 +3,10 @@ plugins {
     id 'org.springframework.boot' version '3.5.12'
     id 'io.spring.dependency-management' version '1.1.7'
 }
+
 ext {
     springCloudVersion = "2025.0.1"
+    querydslVersion = "5.0.0"
 }
 
 group = 'com.winner.client'
@@ -27,48 +29,48 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
+def generated = 'src/main/generated'
 
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+dependencies {
     implementation project(':global')
     implementation project(path: ':global', configuration: 'securityLib')
     implementation project(path: ':global', configuration: 'feignLib')
     implementation project(path: ':global', configuration: 'redisLib')
 
-    // Web & Validation
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-
-    // DB
-    runtimeOnly 'org.postgresql:postgresql'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
-    // Cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
-    // Utils
+    runtimeOnly 'org.postgresql:postgresql'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    // Test
+    implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
-    }
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
-}
-tasks.withType(Test).configureEach {
-    systemProperty "file.encoding", "UTF-8"
-}
-tasks.withType(JavaCompile).configureEach {
-    options.encoding = 'UTF-8'
 }
 
 tasks.named('test') {
@@ -83,9 +85,14 @@ tasks.named('test') {
             }
         }
     }
+
     testLogging {
         events "passed", "skipped", "failed"
         showStandardStreams = true
         exceptionFormat = "full"
     }
+}
+
+tasks.withType(Test).configureEach {
+    systemProperty "file.encoding", "UTF-8"
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/dto/query/AdminUserPageQuery.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/dto/query/AdminUserPageQuery.java
@@ -1,0 +1,22 @@
+package com.winner.client.userservice.user.application.dto.query;
+
+import com.winner.client.global.pagination.PageSortType;
+import com.winner.client.userservice.user.domain.enums.ApprovalStatusType;
+import com.winner.client.userservice.user.domain.enums.RoleType;
+import com.winner.client.userservice.user.domain.enums.UserStatusType;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record AdminUserPageQuery(
+    RoleType role,
+    UUID referenceId,
+    UserStatusType userStatus,
+    ApprovalStatusType approvalStatus,
+    PageSortType sortType,
+    int page,
+    int size
+) {
+
+
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/dto/query/ManagerUserPageQuery.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/dto/query/ManagerUserPageQuery.java
@@ -1,0 +1,18 @@
+package com.winner.client.userservice.user.application.dto.query;
+
+import com.winner.client.global.pagination.PageSortType;
+import com.winner.client.userservice.user.domain.enums.RoleType;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record ManagerUserPageQuery(
+    RoleType role,
+    UUID referenceId,
+    PageSortType sortType,
+    int page,
+    int size
+) {
+
+
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/dto/result/UserSearchResult.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/dto/result/UserSearchResult.java
@@ -1,0 +1,33 @@
+package com.winner.client.userservice.user.application.dto.result;
+
+import com.winner.client.userservice.user.domain.entity.User;
+import com.winner.client.userservice.user.domain.enums.ApprovalStatusType;
+import com.winner.client.userservice.user.domain.enums.UserStatusType;
+import com.winner.client.userservice.user.domain.vo.UserRole;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record UserSearchResult(
+    UUID userId,
+    String name,
+    String slackId,
+    UserStatusType userStatus,
+    ApprovalStatusType approvalStatus,
+    UserRole userRole,
+    LocalDateTime createAt
+) {
+
+  public static UserSearchResult from(User user) {
+    return UserSearchResult.builder()
+        .userId(user.getId())
+        .name(user.getName())
+        .slackId(user.getSlackId())
+        .approvalStatus(user.getApprovalStatus())
+        .userStatus(user.getUserStatus())
+        .userRole(user.getUserRole())
+        .createAt(user.getCreatedAt())
+        .build();
+  }
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/service/UserQueryService.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/service/UserQueryService.java
@@ -1,9 +1,17 @@
 package com.winner.client.userservice.user.application.service;
 
+import com.winner.client.userservice.user.application.dto.query.AdminUserPageQuery;
+import com.winner.client.userservice.user.application.dto.query.ManagerUserPageQuery;
 import com.winner.client.userservice.user.application.dto.result.UserDetailResult;
+import com.winner.client.userservice.user.application.dto.result.UserSearchResult;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 
 public interface UserQueryService {
 
   UserDetailResult getUserDetail(UUID userId);
+
+  Page<UserSearchResult> queryUsersByManage(ManagerUserPageQuery query);
+
+  Page<UserSearchResult> queryUsersByAdmin(AdminUserPageQuery query);
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/service/impl/UserQueryServiceImpl.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/service/impl/UserQueryServiceImpl.java
@@ -2,12 +2,16 @@ package com.winner.client.userservice.user.application.service.impl;
 
 import com.winner.client.global.exception.BusinessException;
 import com.winner.client.userservice.common.exception.UserErrorCode;
+import com.winner.client.userservice.user.application.dto.query.AdminUserPageQuery;
+import com.winner.client.userservice.user.application.dto.query.ManagerUserPageQuery;
 import com.winner.client.userservice.user.application.dto.result.UserDetailResult;
+import com.winner.client.userservice.user.application.dto.result.UserSearchResult;
 import com.winner.client.userservice.user.application.service.UserQueryService;
 import com.winner.client.userservice.user.domain.entity.User;
 import com.winner.client.userservice.user.domain.repository.UserRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,5 +25,17 @@ public class UserQueryServiceImpl implements UserQueryService {
     User user = userRepository.findByIdAndDeletedAtNull(userId)
         .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
     return UserDetailResult.from(user);
+  }
+
+  @Override
+  public Page<UserSearchResult> queryUsersByManage(ManagerUserPageQuery query) {
+    Page<User> userPage = userRepository.findAllByManagerScope(query);
+    return userPage.map(UserSearchResult::from);
+  }
+
+  @Override
+  public Page<UserSearchResult> queryUsersByAdmin(AdminUserPageQuery query) {
+    Page<User> userPage = userRepository.findAllByAdminCondition(query);
+    return userPage.map(UserSearchResult::from);
   }
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/JpaUserRepository.java
@@ -1,11 +1,16 @@
 package com.winner.client.userservice.user.infrastructure.repository;
 
 import com.winner.client.userservice.user.domain.entity.User;
-import com.winner.client.userservice.user.domain.repository.UserRepository;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaUserRepository
-    extends UserRepository, JpaRepository<User, UUID> {
+    extends JpaRepository<User, UUID> {
 
+  boolean existsByUserNameAndDeletedAtNull(String username);
+
+  Optional<User> findByIdAndDeletedAtNull(UUID userId);
+
+  Optional<User> findByUserNameAndDeletedAtNull(String username);
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/UserQueryRepository.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/UserQueryRepository.java
@@ -1,21 +1,11 @@
-package com.winner.client.userservice.user.domain.repository;
+package com.winner.client.userservice.user.infrastructure.repository;
 
 import com.winner.client.userservice.user.application.dto.query.AdminUserPageQuery;
 import com.winner.client.userservice.user.application.dto.query.ManagerUserPageQuery;
 import com.winner.client.userservice.user.domain.entity.User;
-import java.util.Optional;
-import java.util.UUID;
 import org.springframework.data.domain.Page;
 
-public interface UserRepository {
-
-  User save(User user);
-
-  boolean existsByUserNameAndDeletedAtNull(String username);
-
-  Optional<User> findByIdAndDeletedAtNull(UUID userId);
-
-  Optional<User> findByUserNameAndDeletedAtNull(String username);
+public interface UserQueryRepository {
 
   Page<User> findAllByManagerScope(ManagerUserPageQuery query);
 

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/impl/UserQueryRepositoryImpl.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/impl/UserQueryRepositoryImpl.java
@@ -1,0 +1,109 @@
+package com.winner.client.userservice.user.infrastructure.repository.impl;
+
+import static com.winner.client.userservice.user.domain.entity.QUser.user;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.winner.client.global.pagination.PageSortType;
+import com.winner.client.userservice.user.application.dto.query.AdminUserPageQuery;
+import com.winner.client.userservice.user.application.dto.query.ManagerUserPageQuery;
+import com.winner.client.userservice.user.domain.entity.User;
+import com.winner.client.userservice.user.domain.enums.ApprovalStatusType;
+import com.winner.client.userservice.user.domain.enums.RoleType;
+import com.winner.client.userservice.user.domain.enums.UserStatusType;
+import com.winner.client.userservice.user.infrastructure.repository.UserQueryRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+
+  private final JPAQueryFactory queryFactory;
+
+  public Page<User> findAllByManagerScope(ManagerUserPageQuery query) {
+    return fetchUserPage(
+        query.page(),
+        query.size(),
+        query.sortType(),
+        referenceIdEq(query.referenceId()),
+        roleEq(query.role()),
+        user.userStatus.eq(UserStatusType.ACTIVE),
+        user.approvalStatus.eq(ApprovalStatusType.APPROVED), // 승인된 유저만
+        user.deletedAt.isNull()
+    );
+  }
+
+  public Page<User> findAllByAdminCondition(AdminUserPageQuery query) {
+    return fetchUserPage(
+        query.page(),
+        query.size(),
+        query.sortType(),
+        referenceIdEq(query.referenceId()),
+        roleEq(query.role()),
+        userStatusEq(query.userStatus()),
+        approvalStatusEq(query.approvalStatus()),
+        user.deletedAt.isNull()
+    );
+  }
+
+  private BooleanExpression referenceIdEq(UUID referenceId) {
+    return referenceId != null ? user.userRole.referenceId.eq(referenceId) : null;
+  }
+
+  private BooleanExpression roleEq(RoleType role) {
+    return role != null ? user.userRole.role.eq(role) : null;
+  }
+
+  private BooleanExpression userStatusEq(UserStatusType status) {
+    return status != null ? user.userStatus.eq(status) : null;
+  }
+
+  private BooleanExpression approvalStatusEq(ApprovalStatusType status) {
+    return status != null ? user.approvalStatus.eq(status) : null;
+  }
+
+
+  private Page<User> fetchUserPage(int page, int size, PageSortType sortType,
+      BooleanExpression... predicates) {
+    List<User> content = queryFactory
+        .selectFrom(user)
+        .where(predicates)
+        .orderBy(orderSpecifier(sortType))
+        .offset((long) page * size)
+        .limit(size)
+        .fetch();
+
+    Long total = queryFactory
+        .select(user.count())
+        .from(user)
+        .where(predicates)
+        .fetchOne();
+
+    Pageable pageable = PageRequest.of(page, size, Sort.by(sortType.getProperty()));
+    return new PageImpl<>(content, pageable, total != null ? total : 0L);
+  }
+
+  private OrderSpecifier<?> orderSpecifier(PageSortType sortType) {
+    if (sortType == null) {
+      return user.createdAt.desc();
+    }
+
+    return switch (sortType) {
+      case CREATED_AT_ASC -> user.createdAt.asc();
+      case CREATED_AT_DESC -> user.createdAt.desc();
+      case UPDATED_AT_ASC -> user.updatedAt.asc();
+      case UPDATED_AT_DESC -> user.updatedAt.desc();
+    };
+  }
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/impl/UserRepositoryImpl.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/impl/UserRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.winner.client.userservice.user.infrastructure.repository.impl;
+
+import com.winner.client.userservice.user.application.dto.query.AdminUserPageQuery;
+import com.winner.client.userservice.user.application.dto.query.ManagerUserPageQuery;
+import com.winner.client.userservice.user.domain.entity.User;
+import com.winner.client.userservice.user.domain.repository.UserRepository;
+import com.winner.client.userservice.user.infrastructure.repository.JpaUserRepository;
+import com.winner.client.userservice.user.infrastructure.repository.UserQueryRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserRepositoryImpl implements UserRepository {
+
+  private final JpaUserRepository jpaUserRepository;
+  private final UserQueryRepository userQueryRepository;
+
+  public UserRepositoryImpl(JpaUserRepository jpaUserRepository,
+      UserQueryRepository userQueryRepository) {
+    this.jpaUserRepository = jpaUserRepository;
+    this.userQueryRepository = userQueryRepository;
+  }
+
+  @Override
+  public User save(User user) {
+    return jpaUserRepository.save(user);
+  }
+
+  @Override
+  public boolean existsByUserNameAndDeletedAtNull(String username) {
+    return jpaUserRepository.existsByUserNameAndDeletedAtNull(username);
+  }
+
+  @Override
+  public Optional<User> findByIdAndDeletedAtNull(UUID userId) {
+    return jpaUserRepository.findByIdAndDeletedAtNull(userId);
+  }
+
+  @Override
+  public Optional<User> findByUserNameAndDeletedAtNull(String username) {
+    return jpaUserRepository.findByUserNameAndDeletedAtNull(username);
+  }
+
+  @Override
+  public Page<User> findAllByManagerScope(ManagerUserPageQuery query) {
+    return userQueryRepository.findAllByManagerScope(query);
+  }
+
+  @Override
+  public Page<User> findAllByAdminCondition(AdminUserPageQuery query) {
+    return userQueryRepository.findAllByAdminCondition(query);
+  }
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/controller/AdminController.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/controller/AdminController.java
@@ -1,13 +1,20 @@
 package com.winner.client.userservice.user.presentation.controller;
 
+import com.winner.client.global.pagination.CommonPageRequest;
+import com.winner.client.global.pagination.PageResponse;
 import com.winner.client.global.response.ApiResponse;
 import com.winner.client.global.response.CommonSuccessCode;
+import com.winner.client.userservice.user.application.dto.result.UserSearchResult;
 import com.winner.client.userservice.user.application.service.UserQueryService;
+import com.winner.client.userservice.user.presentation.dto.request.AdminUserSearchRequest;
 import com.winner.client.userservice.user.presentation.dto.response.UserDetailResponse;
+import com.winner.client.userservice.user.presentation.dto.response.UserSearchResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,6 +40,27 @@ public class AdminController {
                 UserDetailResponse.from(
                     userQueryService.getUserDetail(userId)
                 )
+            )
+        );
+  }
+
+  @GetMapping()
+  public ResponseEntity<ApiResponse<PageResponse<UserSearchResponse>>> getUsersForAdmin(
+      @ModelAttribute AdminUserSearchRequest searchRequest,
+      CommonPageRequest pageRequest) {
+
+    Page<UserSearchResult> resultPage = userQueryService.queryUsersByAdmin(
+        AdminUserSearchRequest.toQuery(searchRequest, pageRequest));
+    Page<UserSearchResponse> infoPage = resultPage.map(UserSearchResponse::from);
+
+    return ResponseEntity
+        .status(
+            CommonSuccessCode.OK.getStatus()
+        )
+        .body(
+            ApiResponse.success(CommonSuccessCode.OK,
+                "유저 목록을 조회하였습니다.",
+                PageResponse.of(infoPage)
             )
         );
   }

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/controller/InternalController.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/controller/InternalController.java
@@ -1,13 +1,22 @@
 package com.winner.client.userservice.user.presentation.controller;
 
+import com.winner.client.global.pagination.CommonPageRequest;
+import com.winner.client.global.pagination.PageResponse;
 import com.winner.client.global.response.ApiResponse;
 import com.winner.client.global.response.CommonSuccessCode;
+import com.winner.client.global.security.CustomUserPrincipal;
+import com.winner.client.userservice.user.application.dto.result.UserSearchResult;
 import com.winner.client.userservice.user.application.service.UserQueryService;
+import com.winner.client.userservice.user.presentation.dto.request.ManagerUserSearchRequest;
 import com.winner.client.userservice.user.presentation.dto.response.UserDetailResponse;
+import com.winner.client.userservice.user.presentation.dto.response.UserSearchResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,6 +41,31 @@ public class InternalController {
                 "해당 유저를 조회하였습니다.",
                 UserDetailResponse.from(
                     userQueryService.getUserDetail(userId)
+                )
+            )
+        );
+  }
+
+  @GetMapping()
+  public ResponseEntity<ApiResponse<PageResponse<UserSearchResponse>>> getUsersForManager(
+      @ModelAttribute ManagerUserSearchRequest searchRequest,
+      CommonPageRequest pageRequest,
+      @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal) {
+
+    Page<UserSearchResult> resultPage = userQueryService.queryUsersByManage(
+        ManagerUserSearchRequest.toQuery(searchRequest, pageRequest,
+            customUserPrincipal.referenceId()));
+    Page<UserSearchResponse> infoPage = resultPage.map(UserSearchResponse::from);
+
+    return ResponseEntity
+        .status(
+            CommonSuccessCode.OK.getStatus()
+        )
+        .body(
+            ApiResponse.success(CommonSuccessCode.OK,
+                "매니저의 유저 목록을 조회하였습니다.",
+                PageResponse.of(
+                    infoPage
                 )
             )
         );

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/dto/request/AdminUserSearchRequest.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/dto/request/AdminUserSearchRequest.java
@@ -1,0 +1,32 @@
+package com.winner.client.userservice.user.presentation.dto.request;
+
+import com.winner.client.global.pagination.CommonPageRequest;
+import com.winner.client.global.pagination.PageSortType;
+import com.winner.client.userservice.user.application.dto.query.AdminUserPageQuery;
+import com.winner.client.userservice.user.domain.enums.ApprovalStatusType;
+import com.winner.client.userservice.user.domain.enums.RoleType;
+import com.winner.client.userservice.user.domain.enums.UserStatusType;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record AdminUserSearchRequest(
+    RoleType role,
+    ApprovalStatusType approvalStatus,
+    UserStatusType userStatus,
+    UUID referenceId
+) {
+
+  public static AdminUserPageQuery toQuery(AdminUserSearchRequest request,
+      CommonPageRequest pageRequest) {
+    return AdminUserPageQuery.builder()
+        .role(request.role)
+        .userStatus(request.userStatus)
+        .approvalStatus(request.approvalStatus)
+        .referenceId(request.referenceId)
+        .sortType(PageSortType.valueOf(pageRequest.getSort()))
+        .page(pageRequest.getPage())
+        .size(pageRequest.getSize())
+        .build();
+  }
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/dto/request/ManagerUserSearchRequest.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/dto/request/ManagerUserSearchRequest.java
@@ -1,0 +1,26 @@
+package com.winner.client.userservice.user.presentation.dto.request;
+
+import com.winner.client.global.pagination.CommonPageRequest;
+import com.winner.client.global.pagination.PageSortType;
+import com.winner.client.userservice.user.application.dto.query.ManagerUserPageQuery;
+import com.winner.client.userservice.user.domain.enums.RoleType;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record ManagerUserSearchRequest(
+    RoleType role
+) {
+
+  public static ManagerUserPageQuery toQuery
+      (ManagerUserSearchRequest searchRequest,
+          CommonPageRequest pageRequest, UUID referenceId) {
+    return ManagerUserPageQuery.builder()
+        .role(searchRequest.role())
+        .referenceId(referenceId)
+        .sortType(PageSortType.valueOf(pageRequest.getSort()))
+        .page(pageRequest.getPage())
+        .size(pageRequest.getSize())
+        .build();
+  }
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/dto/response/UserSearchResponse.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/dto/response/UserSearchResponse.java
@@ -1,0 +1,33 @@
+package com.winner.client.userservice.user.presentation.dto.response;
+
+import com.winner.client.userservice.user.application.dto.result.UserSearchResult;
+import com.winner.client.userservice.user.domain.enums.ApprovalStatusType;
+import com.winner.client.userservice.user.domain.enums.UserStatusType;
+import com.winner.client.userservice.user.domain.vo.UserRole;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record UserSearchResponse(
+    UUID userId,
+    String name,
+    String slackId,
+    UserStatusType userStatus,
+    ApprovalStatusType approvalStatus,
+    UserRole userRole,
+    LocalDateTime createAt
+) {
+
+  public static UserSearchResponse from(UserSearchResult searchResult) {
+    return UserSearchResponse.builder()
+        .userId(searchResult.userId())
+        .name(searchResult.name())
+        .slackId(searchResult.slackId())
+        .approvalStatus(searchResult.approvalStatus())
+        .userStatus(searchResult.userStatus())
+        .userRole(searchResult.userRole())
+        .createAt(searchResult.createAt())
+        .build();
+  }
+}


### PR DESCRIPTION
### 📎 관련 이슈
- close #165

### 📌 작업 내용
- internal, admin 각 엔드포인트별 목록 조회 로직 구현

internal : 자신의 소속 id로 된 유저들을 조회할 수 있다.
admin : 역할, 상태를 기준으로 조회할 수 있다.

### ✨ 변경 사항
- 주요 변경 내용 정리

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)