### PR TITLE
[feat]: eureka-server, delivery-service 둘 다 docker 로 실행하기 위한 파일 추가

### DIFF
--- a/delivery-service/Dockerfile
+++ b/delivery-service/Dockerfile
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:17-jdk AS build
+WORKDIR /app
+
+COPY . .
+
+RUN chmod +x ./gradlew
+RUN ./gradlew :delivery-service:clean :delivery-service:bootJar
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+
+COPY --from=build /app/delivery-service/build/libs/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/delivery-service/docker-compose.yml
+++ b/delivery-service/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  delivery-service:
+    platform: linux/arm64
+    build:
+      context: ..
+      dockerfile: delivery-service/Dockerfile
+    container_name: delivery-service
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://logistics-postgres:5432/${POSTGRES_DB}?currentSchema=${POSTGRES_DEFAULT_SCHEMA}
+      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}
+      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+      - SPRING_DATA_REDIS_HOST=logistics-redis
+      - SPRING_DATA_REDIS_PORT=6379
+      - SPRING_DATA_REDIS_PASSWORD=${SPRING_DATA_REDIS_PASSWORD}
+    env_file:
+      - .env
+    networks:
+      - logistics-network
+    restart: always
+
+networks:
+  logistics-network:
+    external: true

--- a/delivery-service/src/main/resources/application.yaml
+++ b/delivery-service/src/main/resources/application.yaml
@@ -26,7 +26,7 @@ spring:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:17001/eureka/
+      defaultZone: http://eureka-server:17001/eureka/
     register-with-eureka: true
     fetch-registry: true
   instance:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       timeout: 5s
       retries: 10
       start_period: 30s
+    networks:
+      - logistics-network
     restart: unless-stopped
 
   redis:
@@ -36,8 +38,14 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    networks:
+      - logistics-network
     restart: unless-stopped
 
 volumes:
   pgdata:
   redisdata:
+
+networks:
+  logistics-network:
+    external: true

--- a/eureka-server/Dockerfile
+++ b/eureka-server/Dockerfile
@@ -1,0 +1,13 @@
+FROM eclipse-temurin:17-jdk AS build
+WORKDIR /app
+
+COPY . .
+
+RUN chmod +x ./gradlew
+RUN ./gradlew :eureka-server:clean :eureka-server:bootJar
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/eureka-server/build/libs/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/eureka-server/docker-compose.yml
+++ b/eureka-server/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  eureka-server:
+    platform: linux/arm64
+    build:
+      context: ..
+      dockerfile: eureka-server/Dockerfile
+    container_name: eureka-server
+    ports:
+      - "17001:17001"
+    networks:
+      - logistics-network
+    restart: always
+
+networks:
+  logistics-network:
+    external: true


### PR DESCRIPTION
### 📎 관련 이슈
- close #191 

### 📌 작업 내용
- `eureka-server`를 Docker로 실행할 수 있도록 설정했습니다.
- `delivery-service`를 Docker로 실행할 수 있도록 설정했습니다.
- 각 서비스가 공통 네트워크(`logistics-network`)에서 동작하도록 `docker-compose.yml`을 구성했습니다.
- 서비스 실행에 필요한 환경 변수와 컨테이너 설정을 정리했습니다.

### ✨ 변경 사항
- `eureka-server`용 `Dockerfile` 추가
- `delivery-service`용 `Dockerfile` 추가
- `docker-compose.yml`에 서비스 및 네트워크 설정 추가
- `delivery-service`에 PostgreSQL, Redis 관련 환경 변수 반영

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항
- 이번 변경은 로컬 개발 및 배포 환경에서 서비스 실행을 쉽게 하기 위한 인프라 구성 작업입니다.
- root에 있는 .env에서 다른건 그대로 두고 두가지만 변경
``` vi
# PostgreSQL
POSTGRES_HOST=logistics-postgres
DEFAULT_SCHEMA=
# Redis
REDIS_HOST=logistics-redis 
```
로 변경하기
이미 컨테이너로 실행중인 db에 접속하기 위함

그대로 .env복사해서 자기 프로젝트에 붙여넣기

compose 실행 위치는 logistics-hubs(root project)
>  예시 ``` terminal
docker compose -f delivery-service/docker-compose.yml up -d --build
```
