### PR TITLE
[feat] 허브 검색 API 및 DTO/Command 변환 구조 개선

### DIFF
--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/HubService.java
@@ -12,6 +12,8 @@ import com.winner.client.hubservice.hub.domain.repository.HubRouteRepository;
 import com.winner.client.hubservice.hub.domain.vo.HubLocation;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -87,5 +89,23 @@ public class HubService {
         for (var route : routes) {
             route.delete(userId);
         }
+    }
+
+    public Page<HubResult> searchHubs(String q, Pageable pageable) {
+        Page<Hub> hubs;
+
+        if (q == null || q.isBlank()) {
+            hubs = hubRepository.findAllByDeletedAtIsNull(pageable);
+        } else {
+            hubs = hubRepository.findByNameContainingAndDeletedAtIsNull(q, pageable);
+        }
+
+        return hubs.map(hub -> HubResult.builder()
+            .id(hub.getId())
+            .name(hub.getName())
+            .address(hub.getLocation().getAddress())
+            .lat(hub.getLocation().getLat())
+            .lng(hub.getLocation().getLng())
+            .build());
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/dto/CreateHubCommand.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/dto/CreateHubCommand.java
@@ -1,5 +1,6 @@
 package com.winner.client.hubservice.hub.application.dto;
 
+import com.winner.client.hubservice.hub.presentation.dto.CreateHubRequest;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,4 +12,13 @@ public class CreateHubCommand {
     private String address;
     private double lat;
     private double lng;
+
+    public static CreateHubCommand from(CreateHubRequest request) {
+        return CreateHubCommand.builder()
+            .name(request.getName())
+            .address(request.getAddress())
+            .lat(request.getLat())
+            .lng(request.getLng())
+            .build();
+    }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/application/dto/CreateRouteCommand.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/application/dto/CreateRouteCommand.java
@@ -1,5 +1,6 @@
 package com.winner.client.hubservice.hub.application.dto;
 
+import com.winner.client.hubservice.hub.presentation.dto.CreateHubRouteRequest;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,4 +13,13 @@ public class CreateRouteCommand {
     private UUID toHubId;
     private double distance;
     private int duration;
+
+    public static CreateRouteCommand from(CreateHubRouteRequest request) {
+        return CreateRouteCommand.builder()
+            .fromHubId(request.getFromHubId())
+            .toHubId(request.getToHubId())
+            .distance(request.getDistance())
+            .duration(request.getDuration())
+            .build();
+    }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRepository.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/domain/repository/HubRepository.java
@@ -15,4 +15,6 @@ public interface HubRepository {
     Optional<Hub> findByIdAndDeletedAtIsNull(UUID id);
 
     Page<Hub> findAllByDeletedAtIsNull(Pageable pageable);
+
+    Page<Hub> findByNameContainingAndDeletedAtIsNull(String name, Pageable pageable);
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubController.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubController.java
@@ -10,6 +10,10 @@ import com.winner.client.hubservice.hub.presentation.dto.HubResponse;
 import com.winner.client.hubservice.hub.presentation.dto.UpdateHubRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,12 +34,7 @@ public class HubController {
 
     @PostMapping
     public UUID createHub(@RequestBody CreateHubRequest request) {
-        CreateHubCommand command = CreateHubCommand.builder()
-            .name(request.getName())
-            .address(request.getAddress())
-            .lat(request.getLat())
-            .lng(request.getLng())
-            .build();
+        CreateHubCommand command = CreateHubCommand.from(request);
 
         return hubService.createHub(command);
     }
@@ -43,13 +43,7 @@ public class HubController {
     public HubResponse getHub(@PathVariable UUID hubId) {
         HubResult result = hubService.getHub(hubId);
 
-        return HubResponse.builder()
-            .id(result.getId())
-            .name(result.getName())
-            .address(result.getAddress())
-            .lat(result.getLat())
-            .lng(result.getLng())
-            .build();
+        return HubResponse.from(result);
     }
 
     @PatchMapping("/{hubId}")
@@ -62,5 +56,15 @@ public class HubController {
     @DeleteMapping("/{hubId}")
     public void deleteHub(@PathVariable UUID hubId, @AuthenticationPrincipal CustomUserPrincipal user) {
         hubService.deleteHub(hubId, user.userId());
+    }
+
+    @GetMapping
+    public Page<HubResponse> searchHubs(
+            @RequestParam(required = false) String q,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        return hubService.searchHubs(q, pageable)
+            .map(HubResponse::from);
     }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubRouteController.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/HubRouteController.java
@@ -24,12 +24,7 @@ public class HubRouteController {
 
     @PostMapping
     public UUID createHubRoute(@RequestBody CreateHubRouteRequest request) {
-        CreateRouteCommand command = CreateRouteCommand.builder()
-            .fromHubId(request.getFromHubId())
-            .toHubId(request.getToHubId())
-            .distance(request.getDistance())
-            .duration(request.getDuration())
-            .build();
+        CreateRouteCommand command = CreateRouteCommand.from(request);
 
         return hubRouteService.createRoute(command);
     }
@@ -49,13 +44,7 @@ public class HubRouteController {
         }
 
         return results.stream()
-            .map(result -> HubRouteResponse.builder()
-                .id(result.getId())
-                .fromHubId(result.getFromHubId())
-                .toHubId(result.getToHubId())
-                .distance(result.getDistance())
-                .duration(result.getDuration())
-                .build())
+            .map(HubRouteResponse::from)
             .toList();
     }
 

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/dto/HubResponse.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/dto/HubResponse.java
@@ -1,5 +1,6 @@
 package com.winner.client.hubservice.hub.presentation.dto;
 
+import com.winner.client.hubservice.hub.application.dto.HubResult;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,4 +14,14 @@ public class HubResponse {
     private String address;
     private double lat;
     private double lng;
+
+    public static HubResponse from(HubResult result) {
+        return HubResponse.builder()
+            .id(result.getId())
+            .name(result.getName())
+            .address(result.getAddress())
+            .lat(result.getLat())
+            .lng(result.getLng())
+            .build();
+    }
 }

--- a/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/dto/HubRouteResponse.java
+++ b/hub-service/src/main/java/com/winner/client/hubservice/hub/presentation/dto/HubRouteResponse.java
@@ -1,5 +1,6 @@
 package com.winner.client.hubservice.hub.presentation.dto;
 
+import com.winner.client.hubservice.hub.application.dto.HubRouteResult;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,4 +14,14 @@ public class HubRouteResponse {
     private UUID toHubId;
     private double distance;
     private double duration;
+
+    public static HubRouteResponse from(HubRouteResult result) {
+        return HubRouteResponse.builder()
+            .id(result.getId())
+            .fromHubId(result.getFromHubId())
+            .toHubId(result.getToHubId())
+            .distance(result.getDistance())
+            .duration(result.getDuration())
+            .build();
+    }
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #170 

### 📌 작업 내용
- 허브 검색 API 구현 (q 파라미터 기반 이름 검색)
- Pageable을 활용한 페이징 및 정렬 기능 적용
- q 값이 없는 경우 전체 조회로 fallback 처리
- Hub / HubRoute 도메인에 DTO 변환 구조 개선
    - Request → Command 변환 (from 메서드 적용)
    - Result → Response 변환 (from 메서드 적용)

### ✨ 변경 사항
- `GET /api/v1/hubs?q=` 검색 API 추가
- `Pageable` 기반 페이징 및 정렬 처리
- Controller에서 DTO 변환 로직 제거
- Command/Response 클래스에 변환 책임 위임
- HubRouteController에도 동일한 구조로 리팩토링 적용

### 📝 리뷰 포인트
- DTO 변환 책임을 Command/Response로 이동한 구조가 적절한지
- q 파라미터가 없는 경우 전체 조회로 처리한 방식에 대한 의견
- Hub / HubRoute Controller 간 구조 일관성 확인

### 🧠 기타 참고 사항
- 검색 기능은 현재 LIKE 기반 Containing으로 구현되어 있으며, 추후 인덱싱 또는 검색 최적화 고려 예정입니다.