### PR TITLE
[Feat] 허브/업체 담당자 이벤트 연동 및 배달 API 인증 추가

### DIFF
--- a/delivery-service/build.gradle
+++ b/delivery-service/build.gradle
@@ -48,6 +48,7 @@ clean {
 dependencies {
     implementation project(':global')
     annotationProcessor project(':global')
+    implementation project(path: ':global', configuration: 'securityLib')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/deliverymanager/hub/AssignHubDeliveryManagerFailEvent.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/event/deliverymanager/hub/AssignHubDeliveryManagerFailEvent.java
@@ -1,10 +1,12 @@
 package com.winner.client.deliveryservice.common.event.deliverymanager.hub;
 
+import java.util.UUID;
+
 public record AssignHubDeliveryManagerFailEvent(
 	String message,
-	String deliveryId
+	UUID deliveryId
 ) {
-	public static AssignHubDeliveryManagerFailEvent of(String message, String deliveryId) {
+	public static AssignHubDeliveryManagerFailEvent of(String message, UUID deliveryId) {
 		return new AssignHubDeliveryManagerFailEvent(message, deliveryId);
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/GlobalExceptionHandler.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/GlobalExceptionHandler.java
@@ -3,8 +3,13 @@ package com.winner.client.deliveryservice.common.exception;
 import com.winner.client.global.exception.BusinessException;
 import com.winner.client.global.exception.CommonErrorCode;
 import com.winner.client.global.response.ApiResponse;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,6 +25,32 @@ public class GlobalExceptionHandler {
         .body(ApiResponse.error(e.getErrorCode()));
   }
 
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<ApiResponse<Void>> handleHttpRequestMethodNotSupportedException(
+      HttpRequestMethodNotSupportedException e) {
+    log.warn("HttpRequestMethodNotSupportedException: {}", e.getMessage());
+    return ResponseEntity
+        .status(HttpStatus.METHOD_NOT_ALLOWED)
+        .body(ApiResponse.error(CommonErrorCode.METHOD_NOT_ALLOWED));
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  protected ResponseEntity<ApiResponse<Map<String, String>>> handleMethodArgumentNotValidException(
+      MethodArgumentNotValidException ex
+  ) {
+    Map<String, String> errors = new HashMap<>();
+    ex.getBindingResult().getGlobalErrors().forEach(error ->
+        errors.put(error.getObjectName(), error.getDefaultMessage())
+    );
+    ex.getBindingResult().getFieldErrors().forEach(error ->
+        errors.put(error.getField(), error.getDefaultMessage())
+    );
+
+    log.warn("MethodArgumentNotValidException: {}", errors);
+
+    CommonErrorCode code = CommonErrorCode.INVALID_INPUT;
+    return ResponseEntity.status(code.getStatus()).body(ApiResponse.error(code, errors));
+  }
 
   @ExceptionHandler(Exception.class)
   protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompanyDeliveryManagerAssignFailCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompanyDeliveryManagerAssignFailCommand.java
@@ -1,8 +1,15 @@
 package com.winner.client.deliveryservice.delivery.application.dto.command;
 
+import com.winner.client.deliveryservice.common.event.deliverymanager.company.AssignCompanyDeliveryManagerFailEvent;
 import java.util.UUID;
 
 public record CompanyDeliveryManagerAssignFailCommand(
     String failReason,
     UUID deliveryId
-) {}
+) {
+  public static CompanyDeliveryManagerAssignFailCommand from(
+      AssignCompanyDeliveryManagerFailEvent event) {
+    return new CompanyDeliveryManagerAssignFailCommand(
+        event.message(), event.deliveryId());
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompleteDeliveryCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompleteDeliveryCommand.java
@@ -1,8 +1,15 @@
 package com.winner.client.deliveryservice.delivery.application.dto.command;
 
+import com.winner.client.deliveryservice.common.event.deliverymanager.company.DeliveryFinalCompleteEvent;
 import java.util.UUID;
 
 public record CompleteDeliveryCommand(
     UUID deliveryId, UUID deliveryManagerId
 ) {
+  public static CompleteDeliveryCommand from(DeliveryFinalCompleteEvent event) {
+    return new CompleteDeliveryCommand(
+        event.deliveryId(),
+        event.managerId()
+    );
+  }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompleteDeliveryRouteCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/CompleteDeliveryRouteCommand.java
@@ -1,8 +1,15 @@
 package com.winner.client.deliveryservice.delivery.application.dto.command;
 
+import com.winner.client.deliveryservice.common.event.deliverymanager.hub.DeliveryCompleteEvent;
 import java.util.UUID;
 
 public record CompleteDeliveryRouteCommand(
     UUID deliveryId, UUID deliveryManagerId
 ) {
+  public static CompleteDeliveryRouteCommand from(DeliveryCompleteEvent event) {
+    return new CompleteDeliveryRouteCommand(
+        event.deliveryId(),
+        event.managerId()
+    );
+  }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/DeliveryAssignCompleteCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/DeliveryAssignCompleteCommand.java
@@ -1,5 +1,6 @@
 package com.winner.client.deliveryservice.delivery.application.dto.command;
 
+import com.winner.client.deliveryservice.common.event.deliverymanager.company.AssignCompanyDeliveryManagerSuccessEvent;
 import java.util.UUID;
 
 public record DeliveryAssignCompleteCommand(
@@ -7,4 +8,11 @@ public record DeliveryAssignCompleteCommand(
     UUID deliveryManagerId,
     String deliveryManagerName
 ) {
+  public static DeliveryAssignCompleteCommand from(AssignCompanyDeliveryManagerSuccessEvent event) {
+    return new DeliveryAssignCompleteCommand(
+        event.deliveryId(),
+        event.deliveryManagerId(),
+        event.name()
+    );
+  }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/DeliveryRouteAssignCompleteCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/DeliveryRouteAssignCompleteCommand.java
@@ -1,9 +1,18 @@
 package com.winner.client.deliveryservice.delivery.application.dto.command;
 
+import com.winner.client.deliveryservice.common.event.deliverymanager.hub.AssignHubDeliveryManagerSuccessEvent;
 import java.util.UUID;
 
 public record DeliveryRouteAssignCompleteCommand(
     UUID deliveryId,
     UUID deliveryManagerId,
     String deliveryManagerName
-) {}
+) {
+  public static DeliveryRouteAssignCompleteCommand from(AssignHubDeliveryManagerSuccessEvent event) {
+    return new DeliveryRouteAssignCompleteCommand(
+        event.deliveryId(),
+        event.deliveryManagerId(),
+        event.name()
+    );
+  }
+}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/HubDeliveryManagerAssignFailCommand.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/dto/command/HubDeliveryManagerAssignFailCommand.java
@@ -1,9 +1,16 @@
 package com.winner.client.deliveryservice.delivery.application.dto.command;
 
+import com.winner.client.deliveryservice.common.event.deliverymanager.hub.AssignHubDeliveryManagerFailEvent;
 import java.util.UUID;
 
 public record HubDeliveryManagerAssignFailCommand(
     String failReason,
     UUID deliveryId
 ) {
+  public static HubDeliveryManagerAssignFailCommand from(AssignHubDeliveryManagerFailEvent event) {
+    return new HubDeliveryManagerAssignFailCommand(
+        event.message(),
+        event.deliveryId()
+    );
+  }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/port/OrderPort.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/port/OrderPort.java
@@ -3,6 +3,6 @@ package com.winner.client.deliveryservice.delivery.application.port;
 import java.util.UUID;
 
 public interface OrderPort {
-  void updateOrderDeliveryInfo(UUID deliveryId, UUID deliveryManagerId, String deliveryStatus);
-  void updateOrderDeliveryCompleted(UUID deliveryId);
+  void updateOrderDeliveryInfo(UUID orderId, UUID deliveryManagerId);
+  void updateOrderDeliveryCompleted(UUID orderId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryMessageServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryMessageServiceImpl.java
@@ -46,9 +46,8 @@ public class DeliveryMessageServiceImpl implements DeliveryMessageUsecase {
     }
 
     orderPort.updateOrderDeliveryInfo(
-        command.deliveryId(),
-        command.deliveryManagerId(),
-        delivery.getStatus().name()
+        delivery.getOrdersId(),
+        command.deliveryManagerId()
     );
   }
 
@@ -61,9 +60,8 @@ public class DeliveryMessageServiceImpl implements DeliveryMessageUsecase {
     delivery.startVendorMoving();
 
     orderPort.updateOrderDeliveryInfo(
-        command.deliveryId(),
-        command.deliveryManagerId(),
-        delivery.getStatus().name()
+        delivery.getOrdersId(),
+        command.deliveryManagerId()
     );
   }
 
@@ -91,7 +89,7 @@ public class DeliveryMessageServiceImpl implements DeliveryMessageUsecase {
     Delivery delivery = findDeliveryById(command.deliveryId());
     delivery.complete();
 
-    orderPort.updateOrderDeliveryCompleted(command.deliveryId());
+    orderPort.updateOrderDeliveryCompleted(delivery.getOrdersId());
   }
 
   @Override

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/validator/DeliveryAccessValidator.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/validator/DeliveryAccessValidator.java
@@ -44,7 +44,7 @@ public class DeliveryAccessValidator {
   }
 
   public void validateHubAdminAccess(Delivery delivery, String userRole, UUID userHubId) {
-    validateRole(userRole, "MASTER_ADMIN", "HUB_ADMIN");
+    validateRole(userRole, "MASTER", "HUB_ADMIN");
 
     if ("HUB_ADMIN".equals(userRole)) {
       validateDeliveryHubAccess(delivery, userHubId);
@@ -54,7 +54,7 @@ public class DeliveryAccessValidator {
   public void validateDeliveryManagerAccess(
       Delivery delivery, UUID userId, String userRole, UUID userHubId
   ) {
-    validateRole(userRole, "MASTER_ADMIN", "HUB_ADMIN", "DELIVERY_MANAGER");
+    validateRole(userRole, "MASTER", "HUB_ADMIN", "DELIVERY_MANAGER");
 
     switch (userRole) {
       case "HUB_ADMIN" -> validateDeliveryHubAccess(delivery, userHubId);
@@ -64,7 +64,7 @@ public class DeliveryAccessValidator {
   }
 
   public void validateRouteHubAdminAccess(DeliveryRoute route, String userRole, UUID userHubId) {
-    validateRole(userRole, "MASTER_ADMIN", "HUB_ADMIN");
+    validateRole(userRole, "MASTER", "HUB_ADMIN");
 
     if ("HUB_ADMIN".equals(userRole)) {
       validateRouteHubAccess(route, userHubId);
@@ -74,7 +74,7 @@ public class DeliveryAccessValidator {
   public void validateRouteDeliveryManagerAccess(
       DeliveryRoute route, UUID userId, String userRole, UUID userHubId
   ) {
-    validateRole(userRole, "MASTER_ADMIN", "HUB_ADMIN", "DELIVERY_MANAGER");
+    validateRole(userRole, "MASTER", "HUB_ADMIN", "DELIVERY_MANAGER");
 
     switch (userRole) {
       case "HUB_ADMIN" -> validateRouteHubAccess(route, userHubId);

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/OrderClient.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/OrderClient.java
@@ -1,17 +1,17 @@
 package com.winner.client.deliveryservice.delivery.infrastructure.client;
 
-import com.winner.client.deliveryservice.delivery.infrastructure.client.dto.UpdateOrderInfoRequest;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name="order-service")
 public interface OrderClient {
-  @PatchMapping("/internal/v1/orders}")
-  void updateOrderInfo(@RequestBody UpdateOrderInfoRequest request);
+  @PostMapping("/internal/v1/orders/{orderId}}")
+  void updateOrderInfo(@PathVariable UUID orderId, @RequestParam UUID deliveryManagerId);
 
-  @PatchMapping("/internal/v1/orders")
-  void updateDeliveryCompleted(@RequestParam UUID deliveryId);
+  @PatchMapping("/internal/v1/orders/{orderId}/completion")
+  void updateDeliveryCompleted(@PathVariable UUID orderId);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/OrderClientAdapter.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/OrderClientAdapter.java
@@ -1,7 +1,6 @@
 package com.winner.client.deliveryservice.delivery.infrastructure.client;
 
 import com.winner.client.deliveryservice.delivery.application.port.OrderPort;
-import com.winner.client.deliveryservice.delivery.infrastructure.client.dto.UpdateOrderInfoRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,14 +12,12 @@ public class OrderClientAdapter implements OrderPort {
   private final OrderClient orderClient;
 
   @Override
-  public void updateOrderDeliveryInfo(UUID deliveryId, UUID deliveryManagerId, String deliveryStatus) {
-    orderClient.updateOrderInfo(
-        new UpdateOrderInfoRequest(deliveryId, deliveryManagerId, deliveryStatus)
-    );
+  public void updateOrderDeliveryInfo(UUID orderId, UUID deliveryManagerId) {
+    orderClient.updateOrderInfo(orderId, deliveryManagerId);
   }
 
   @Override
-  public void updateOrderDeliveryCompleted(UUID deliveryId) {
-    orderClient.updateDeliveryCompleted(deliveryId);
+  public void updateOrderDeliveryCompleted(UUID orderId) {
+    orderClient.updateDeliveryCompleted(orderId);
   }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/dto/UpdateOrderInfoRequest.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/client/dto/UpdateOrderInfoRequest.java
@@ -1,8 +1,0 @@
-package com.winner.client.deliveryservice.delivery.infrastructure.client.dto;
-
-import java.util.UUID;
-
-public record UpdateOrderInfoRequest(
-    UUID delivery, UUID deliveryManagerId, String deliveryStatus
-) {
-}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/message/DeliverySpringEventListener.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/message/DeliverySpringEventListener.java
@@ -1,12 +1,24 @@
 package com.winner.client.deliveryservice.delivery.infrastructure.message;
 
+import com.winner.client.deliveryservice.common.event.deliverymanager.company.AssignCompanyDeliveryManagerFailEvent;
+import com.winner.client.deliveryservice.common.event.deliverymanager.company.AssignCompanyDeliveryManagerSuccessEvent;
+import com.winner.client.deliveryservice.common.event.deliverymanager.company.DeliveryFinalCompleteEvent;
 import com.winner.client.deliveryservice.common.event.deliverymanager.hub.AssignHubDeliveryManagerFailEvent;
 import com.winner.client.deliveryservice.common.event.deliverymanager.hub.AssignHubDeliveryManagerSuccessEvent;
+import com.winner.client.deliveryservice.common.event.deliverymanager.hub.DeliveryCompleteEvent;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CompanyDeliveryManagerAssignFailCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CompleteDeliveryCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.CompleteDeliveryRouteCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryAssignCompleteCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.DeliveryRouteAssignCompleteCommand;
+import com.winner.client.deliveryservice.delivery.application.dto.command.HubDeliveryManagerAssignFailCommand;
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryMessageUsecase;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DeliverySpringEventListener {
@@ -14,10 +26,38 @@ public class DeliverySpringEventListener {
 	private final DeliveryMessageUsecase usecase;
 
 	@EventListener
-	public void successEventPublish(AssignHubDeliveryManagerSuccessEvent event) {
+	public void handleHubAssignSuccess(AssignHubDeliveryManagerSuccessEvent event) {
+		log.info("Hub 배정 성공 이벤트 수신: {}", event.deliveryId());
+		usecase.completeHubDeliveryManagerAssign(DeliveryRouteAssignCompleteCommand.from(event));
 	}
 
 	@EventListener
-	public void failEventPublish(AssignHubDeliveryManagerFailEvent event) {
+	public void handleHubAssignFail(AssignHubDeliveryManagerFailEvent event) {
+		log.error("Hub 배정 실패 이벤트 수신: {}", event.message());
+		usecase.retryHubDeliveryManagerAssign(HubDeliveryManagerAssignFailCommand.from(event));
+	}
+
+	@EventListener
+	public void handleHubDeliveryComplete(DeliveryCompleteEvent event) {
+		log.info("Hub 배달 완료 이벤트 수신: {}", event.deliveryId());
+		usecase.completeDeliveryRoute(CompleteDeliveryRouteCommand.from(event));
+	}
+
+	@EventListener
+	public void handleCompanyAssignSuccess(AssignCompanyDeliveryManagerSuccessEvent event) {
+		log.info("업체 배정 성공 이벤트 수신: {}", event.deliveryId());
+		usecase.completeCompanyDeliveryManagerAssign(DeliveryAssignCompleteCommand.from(event));
+	}
+
+	@EventListener
+	public void handleCompanyAssignFail(AssignCompanyDeliveryManagerFailEvent event) {
+		log.error("업체 배정 실패 이벤트 수신 {}", event.message());
+		usecase.retryCompanyDeliveryManagerAssign(CompanyDeliveryManagerAssignFailCommand.from(event));
+	}
+
+	@EventListener
+	public void handleCompanyFinalComplete(DeliveryFinalCompleteEvent event) {
+		log.info("최종 배달 완료 이벤트 수신: {}", event.deliveryId());
+		usecase.completeDelivery(CompleteDeliveryCommand.from(event));
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/custom/DeliveryCustomRepositoryImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/custom/DeliveryCustomRepositoryImpl.java
@@ -26,14 +26,14 @@ public class DeliveryCustomRepositoryImpl implements DeliveryCustomRepository {
 
   @Override
   public Page<Delivery> getAllDeliveries(SearchDeliveryQuery query) {
-    BooleanExpression condition = roleCondition(query)
-        .and(keywordCondition(query.keyword()))
-        .and(statusCondition(query.status()))
-        .and(delivery.deletedAt.isNull());
-
     List<Delivery> content = queryFactory
         .selectFrom(delivery)
-        .where(condition)
+        .where(
+            roleCondition(query),
+            keywordCondition(query.keyword()),
+            statusCondition(query.status()),
+            delivery.deletedAt.isNull()
+        )
         .orderBy(orderSpecifier(query.sortType()))
         .offset((long) query.page() * query.size())
         .limit(query.size())
@@ -42,7 +42,12 @@ public class DeliveryCustomRepositoryImpl implements DeliveryCustomRepository {
     Long total = queryFactory
         .select(delivery.count())
         .from(delivery)
-        .where(condition)
+        .where(
+            roleCondition(query),
+            keywordCondition(query.keyword()),
+            statusCondition(query.status()),
+            delivery.deletedAt.isNull()
+        )
         .fetchOne();
 
     Pageable pageable = PageRequest.of(query.page(), query.size(), Sort.by(query.sortType().getProperty()));
@@ -56,7 +61,7 @@ public class DeliveryCustomRepositoryImpl implements DeliveryCustomRepository {
 
   private BooleanExpression roleCondition(SearchDeliveryQuery query) {
     return switch (query.userRole()) {
-      case "MASTER_ADMIN" -> null;
+      case "MASTER" -> null;
       case "HUB_MANAGER" ->
           delivery.hubRoute.originHubId.eq(query.referenceId())
               .or(delivery.hubRoute.destinationHubId.eq(query.referenceId()));

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/DeliveryController.java
@@ -12,14 +12,17 @@ import com.winner.client.global.pagination.CommonPageRequest;
 import com.winner.client.global.pagination.PageResponse;
 import com.winner.client.global.response.ApiResponse;
 import com.winner.client.global.response.CommonSuccessCode;
+import com.winner.client.global.security.CustomUserPrincipal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,14 +37,13 @@ public class DeliveryController {
   @GetMapping
   public ResponseEntity<ApiResponse<PageResponse<DeliveryInfoResponse>>> getMyDeliveries(
       CommonPageRequest pageRequest,
+      @AuthenticationPrincipal CustomUserPrincipal principal,
       @RequestParam(value = "keyword", required = false) String keyword,
-      @RequestParam(value = "delivery-status", required = false) String deliveryStatus,
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
-      @RequestHeader("X-Reference-Id") UUID referenceId
+      @RequestParam(value = "delivery-status", required = false) String deliveryStatus
   ) {
     SearchDeliveryQuery query =
-        SearchDeliveryQuery.of(userId, userRole, referenceId, keyword, deliveryStatus, pageRequest);
+        SearchDeliveryQuery.of(
+            principal.userId(), principal.role(), principal.referenceId(), keyword, deliveryStatus, pageRequest);
 
     Page<SearchDeliveryResult> resultPage = deliveryQueryService.getDeliveryPage(query);
     Page<DeliveryInfoResponse> infoPage = resultPage.map(DeliveryInfoResponse::from);
@@ -51,7 +53,8 @@ public class DeliveryController {
   }
 
   @GetMapping("/{deliveryId}")
-  public ResponseEntity<ApiResponse<GetDeliveryResponse>> getDeliveryDetail(@PathVariable UUID deliveryId) {
+  public ResponseEntity<ApiResponse<GetDeliveryResponse>> getDeliveryDetail(
+      @AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable UUID deliveryId) {
     GetDeliveryResponse response =
         GetDeliveryResponse.from(deliveryQueryService.getDeliveryDetail(deliveryId));
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
@@ -59,21 +62,22 @@ public class DeliveryController {
   }
 
   @GetMapping("/{deliveryId}/routes")
-  public ResponseEntity<ApiResponse<ListDeliveryRouteResponse>> getDeliveryRoutes(@PathVariable UUID deliveryId){
+  public ResponseEntity<ApiResponse<ListDeliveryRouteResponse>> getDeliveryRoutes(
+      @AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable UUID deliveryId){
     ListDeliveryRouteResponse response =
         ListDeliveryRouteResponse.from(deliveryQueryService.getDeliveryRoutes(deliveryId));
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
   }
 
+  @PreAuthorize("hasAnyRole('MASTER', 'HUB_MANAGER')")
   @PatchMapping("/{deliveryId}/hub-moving")
   public ResponseEntity<ApiResponse<DeliveryCommandResponse>> startHubMoving(
       @PathVariable UUID deliveryId,
-      @RequestHeader("X-User-Role") String userRole,
-      @RequestHeader("X-Reference-Id") UUID referenceId
+      @AuthenticationPrincipal CustomUserPrincipal principal
   ){
     DeliveryCommandResponse response =
-        deliveryCommandService.startHubMoving(deliveryId, userRole, referenceId);
+        deliveryCommandService.startHubMoving(deliveryId, principal.role(), principal.referenceId());
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
   }
@@ -81,12 +85,10 @@ public class DeliveryController {
   @PatchMapping("/{deliveryId}/destination-arrived")
   public ResponseEntity<ApiResponse<DeliveryCommandResponse>> startVendorMoving(
       @PathVariable UUID deliveryId,
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
-      @RequestHeader("X-Reference-Id") UUID referenceId
+      @AuthenticationPrincipal CustomUserPrincipal principal
   ){
     DeliveryCommandResponse response
-        = deliveryCommandService.startVendorMoving(deliveryId, userId, userRole, referenceId);
+        = deliveryCommandService.startVendorMoving(deliveryId, principal.userId(), principal.role(), principal.referenceId());
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
   }
@@ -94,11 +96,10 @@ public class DeliveryController {
   @PatchMapping("/{deliveryId}/for-vendor-moving")
   public ResponseEntity<ApiResponse<DeliveryCommandResponse>> arriveDestination(
       @PathVariable UUID deliveryId,
-      @RequestHeader("X-User-Role") String userRole,
-      @RequestHeader("X-Reference-Id") UUID referenceId
+      @AuthenticationPrincipal CustomUserPrincipal principal
   ){
     DeliveryCommandResponse response =
-        deliveryCommandService.arriveDestination(deliveryId, userRole, referenceId);
+        deliveryCommandService.arriveDestination(deliveryId, principal.role(), principal.referenceId());
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
   }
@@ -106,23 +107,22 @@ public class DeliveryController {
   @PatchMapping("/{deliveryId}/completed")
   public ResponseEntity<ApiResponse<DeliveryCommandResponse>> completeDelivery(
       @PathVariable UUID deliveryId,
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
-      @RequestHeader("X-Reference-Id") UUID referenceId
+      @AuthenticationPrincipal CustomUserPrincipal principal
   ){
     DeliveryCommandResponse response =
-        deliveryCommandService.completeDelivery(deliveryId, userId, userRole, referenceId);
+        deliveryCommandService.completeDelivery(deliveryId, principal.userId(), principal.role(), principal.referenceId());
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
   }
 
-  @PatchMapping("/{deliveryId}/cancelled")
+  @PreAuthorize("hasRole('MASTER')")
+  @PostMapping("/{deliveryId}/cancelled")
   public ResponseEntity<ApiResponse<DeliveryCommandResponse>> cancelDelivery(
       @PathVariable UUID deliveryId,
-      @RequestHeader("X-User-Role") String userRole
+      @AuthenticationPrincipal CustomUserPrincipal principal
   ){
     DeliveryCommandResponse response
-        = deliveryCommandService.cancelDelivery(deliveryId, userRole);
+        = deliveryCommandService.cancelDelivery(deliveryId, principal.role());
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
   }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/message/DeliveryManagerCompanySpringEventListener.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/infrastructure/message/DeliveryManagerCompanySpringEventListener.java
@@ -16,6 +16,6 @@ public class DeliveryManagerCompanySpringEventListener {
 	@EventListener
 	public void assignDeliveryManagerCompany(AssignDeliveryManagerCompanyEvent event) {
 		usecase.assignHubDeliveryManager(
-			DeliveryManagerAssignEventCommand.of(event.deliveryId(), event.toHubId()));
+			DeliveryManagerAssignEventCommand.of(event.deliveryId(), event.hubId()));
 	}
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryMessagePortImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/infrastructure/message/DeliveryMessagePortImpl.java
@@ -25,7 +25,7 @@ public class DeliveryMessagePortImpl implements DeliveryMessagePort {
 			);
 		} else {
 			publisher.publishEvent(AssignHubDeliveryManagerFailEvent
-				.of(result.getErrorMessage(), result.getDeliveryManagerName()));
+				.of(result.getErrorMessage(), result.getDeliveryId()));
 		}
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     container_name: logistics-redis
     ports:
       - "${SPRING_DATA_REDIS_PORT}:6379"
-    command: redis-server --requirepass ${SPRING_DATA_REDIS_PASSWORD}
+    command: redis-server --requirepass ${SPRING_DATA_REDIS_PASSWORD} --bind 0.0.0.0
     env_file:
       - .env
     volumes:

--- a/gateway/src/main/resources/application-router.yaml
+++ b/gateway/src/main/resources/application-router.yaml
@@ -24,15 +24,10 @@ spring:
               predicates:
                 - Path=/api/v1/companies/**
 
-            - id: shipping-service
-              uri: lb://SHIPPING-SERVICE
+            - id: delivery-service
+              uri: lb://DELIVERY-SERVICE
               predicates:
-                - Path=/api/v1/deliveries/**
-
-            - id: driver-service
-              uri: lb://DRIVER-SERVICE
-              predicates:
-                - Path=/api/v1/delivery-managers/**
+                - Path=/api/v1/deliveries/**, /api/v1/delivery-managers/**
 
             - id: hub-service
               uri: lb://HUB-SERVICE


### PR DESCRIPTION
### 📎 관련 이슈
- close #182

### 📌 작업 내용
- 허브/업체 배송 담당자 이벤트에 따라 이벤트 리스너를 수정하였습니다.
- 주문 정보 수정 요청 Feign Client 수정
- DeliveryController에 CustomUserPrincipal 를 활용한 인증을 추가하였습니다.
- Querydsl 파라미터 null로 인한 오류를 수정하였습니다.

### ✨ 변경 사항
- 주문 수정 시 deliveryId -> orderId로 식별자를 변경하여 전달하였습니다.

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)