### PR TITLE
{Feat] 유저 권한 해제 API 구현

### DIFF
--- a/gateway/src/main/java/com/winner/client/gateway/filter/JwtAuthenticationFilter.java
+++ b/gateway/src/main/java/com/winner/client/gateway/filter/JwtAuthenticationFilter.java
@@ -71,7 +71,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
       Claims claims = jwtTokenProvider.getClaims(token);
 
       String userId = claims.getSubject();
-      String userRole = claims.get("role", String.class);
+      String userRole = String.valueOf(claims.get("role"));
       String userStatus = String.valueOf(claims.get("status"));
       String referenceId =
           claims.get("referenceId") != null ? String.valueOf(claims.get("referenceId")) : "";

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/dto/command/UnAssignManagersCommand.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/dto/command/UnAssignManagersCommand.java
@@ -1,0 +1,16 @@
+package com.winner.client.userservice.user.application.dto.command;
+
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record UnAssignManagersCommand(
+    UUID referenceId
+) {
+
+  public static UnAssignManagersCommand from(UUID referenceId) {
+    return UnAssignManagersCommand.builder()
+        .referenceId(referenceId)
+        .build();
+  }
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/dto/result/UserDetailResult.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/dto/result/UserDetailResult.java
@@ -4,7 +4,6 @@ import com.winner.client.userservice.user.domain.entity.User;
 import com.winner.client.userservice.user.domain.enums.ApprovalStatusType;
 import com.winner.client.userservice.user.domain.enums.UserStatusType;
 import com.winner.client.userservice.user.domain.vo.PhoneNumber;
-import com.winner.client.userservice.user.domain.vo.UserRole;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
@@ -18,7 +17,8 @@ public record UserDetailResult(
     String slackId,
     UserStatusType userStatus,
     ApprovalStatusType approvalStatus,
-    UserRole userRole,
+    String role,
+    UUID referenceId,
     LocalDateTime updatedAt
 ) {
 
@@ -31,7 +31,8 @@ public record UserDetailResult(
         .slackId(user.getSlackId())
         .approvalStatus(user.getApprovalStatus())
         .userStatus(user.getUserStatus())
-        .userRole(user.getUserRole())
+        .role(user.getRoleName())
+        .referenceId(user.getReferenceId())
         .updatedAt(user.getUpdatedAt())
         .build();
   }

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/service/UserCommandService.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/service/UserCommandService.java
@@ -1,5 +1,6 @@
 package com.winner.client.userservice.user.application.service;
 
+import com.winner.client.userservice.user.application.dto.command.UnAssignManagersCommand;
 import com.winner.client.userservice.user.application.dto.command.UserPatchCommand;
 import com.winner.client.userservice.user.application.dto.result.UserDetailResult;
 import java.util.UUID;
@@ -9,4 +10,6 @@ public interface UserCommandService {
   Void logout(UUID userId, String accessToken);
 
   UserDetailResult updateUser(UserPatchCommand command);
+
+  Void unAssignManagersFromAdmin(UnAssignManagersCommand command);
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/service/impl/UserCommandServiceImpl.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/service/impl/UserCommandServiceImpl.java
@@ -3,6 +3,7 @@ package com.winner.client.userservice.user.application.service.impl;
 import com.winner.client.global.config.jwt.JwtTokenProvider;
 import com.winner.client.global.exception.BusinessException;
 import com.winner.client.userservice.common.exception.UserErrorCode;
+import com.winner.client.userservice.user.application.dto.command.UnAssignManagersCommand;
 import com.winner.client.userservice.user.application.dto.command.UserPatchCommand;
 import com.winner.client.userservice.user.application.dto.result.UserDetailResult;
 import com.winner.client.userservice.user.application.service.UserCommandService;
@@ -10,6 +11,7 @@ import com.winner.client.userservice.user.domain.entity.User;
 import com.winner.client.userservice.user.domain.repository.TokenRepository;
 import com.winner.client.userservice.user.domain.repository.UserRepository;
 import com.winner.client.userservice.user.domain.vo.PhoneNumber;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,5 +47,12 @@ public class UserCommandServiceImpl implements UserCommandService {
         command.slackId()
     );
     return UserDetailResult.from(user);
+  }
+
+  @Override
+  public Void unAssignManagersFromAdmin(UnAssignManagersCommand command) {
+    List<User> users = userRepository.findAllByReferenceId(command.referenceId());
+    users.forEach(User::suspend);
+    return null;
   }
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/domain/entity/User.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/domain/entity/User.java
@@ -1,8 +1,6 @@
 package com.winner.client.userservice.user.domain.entity;
 
 import com.winner.client.global.entity.BaseAuditEntity;
-import com.winner.client.global.exception.BusinessException;
-import com.winner.client.userservice.common.exception.UserErrorCode;
 import com.winner.client.userservice.user.domain.enums.ApprovalStatusType;
 import com.winner.client.userservice.user.domain.enums.UserStatusType;
 import com.winner.client.userservice.user.domain.vo.Password;
@@ -102,7 +100,7 @@ public class User extends BaseAuditEntity {
 
   public String getRoleName() {
     if (userRole == null || userRole.getRole() == null) {
-      throw new BusinessException(UserErrorCode.INVALID_ROLE);
+      return null;
     }
     return userRole.getRole().name();
   }
@@ -124,6 +122,11 @@ public class User extends BaseAuditEntity {
 
   public void reject() {
     this.approvalStatus = ApprovalStatusType.REJECTED;
+  }
+
+  public void suspend() {
+    this.userStatus = UserStatusType.SUSPEND;
+    this.userRole = null;
   }
 
   public void active() {

--- a/user-service/src/main/java/com/winner/client/userservice/user/domain/enums/UserStatusType.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/domain/enums/UserStatusType.java
@@ -3,5 +3,6 @@ package com.winner.client.userservice.user.domain.enums;
 public enum UserStatusType {
   INACTIVE,
   ACTIVE,
+  SUSPEND,
   DELETED
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/domain/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.winner.client.userservice.user.domain.repository;
 import com.winner.client.userservice.user.application.dto.query.AdminUserPageQuery;
 import com.winner.client.userservice.user.application.dto.query.ManagerUserPageQuery;
 import com.winner.client.userservice.user.domain.entity.User;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -20,4 +21,6 @@ public interface UserRepository {
   Page<User> findAllByManagerScope(ManagerUserPageQuery query);
 
   Page<User> findAllByAdminCondition(AdminUserPageQuery query);
+
+  List<User> findAllByReferenceId(UUID referenceId);
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/domain/vo/UserRole.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/domain/vo/UserRole.java
@@ -3,7 +3,6 @@ package com.winner.client.userservice.user.domain.vo;
 import com.winner.client.global.exception.BusinessException;
 import com.winner.client.userservice.common.exception.UserErrorCode;
 import com.winner.client.userservice.user.domain.enums.RoleType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -17,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 public class UserRole {
 
   @Enumerated(EnumType.STRING)
-  @Column(nullable = false)
   private RoleType role;
   private UUID referenceId;
 

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/JpaUserRepository.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/JpaUserRepository.java
@@ -1,6 +1,7 @@
 package com.winner.client.userservice.user.infrastructure.repository;
 
 import com.winner.client.userservice.user.domain.entity.User;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,6 @@ public interface JpaUserRepository
   Optional<User> findByIdAndDeletedAtNull(UUID userId);
 
   Optional<User> findByUserNameAndDeletedAtNull(String username);
+
+  List<User> findAllByUserRole_ReferenceId(UUID referenceId);
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/impl/UserRepositoryImpl.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/repository/impl/UserRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.winner.client.userservice.user.domain.entity.User;
 import com.winner.client.userservice.user.domain.repository.UserRepository;
 import com.winner.client.userservice.user.infrastructure.repository.JpaUserRepository;
 import com.winner.client.userservice.user.infrastructure.repository.UserQueryRepository;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -51,5 +52,10 @@ public class UserRepositoryImpl implements UserRepository {
   @Override
   public Page<User> findAllByAdminCondition(AdminUserPageQuery query) {
     return userQueryRepository.findAllByAdminCondition(query);
+  }
+
+  @Override
+  public List<User> findAllByReferenceId(UUID referenceId) {
+    return jpaUserRepository.findAllByUserRole_ReferenceId(referenceId);
   }
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/controller/InternalController.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/controller/InternalController.java
@@ -5,7 +5,9 @@ import com.winner.client.global.pagination.PageResponse;
 import com.winner.client.global.response.ApiResponse;
 import com.winner.client.global.response.CommonSuccessCode;
 import com.winner.client.global.security.CustomUserPrincipal;
+import com.winner.client.userservice.user.application.dto.command.UnAssignManagersCommand;
 import com.winner.client.userservice.user.application.dto.result.UserSearchResult;
+import com.winner.client.userservice.user.application.service.UserCommandService;
 import com.winner.client.userservice.user.application.service.UserQueryService;
 import com.winner.client.userservice.user.presentation.dto.request.ManagerUserSearchRequest;
 import com.winner.client.userservice.user.presentation.dto.response.UserDetailResponse;
@@ -14,6 +16,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -27,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class InternalController {
 
   private final UserQueryService userQueryService;
+  private final UserCommandService userCommandService;
 
   @GetMapping("/{userId}")
   public ResponseEntity<ApiResponse<UserDetailResponse>> getUserDetailsForManager(
@@ -67,6 +71,25 @@ public class InternalController {
                 PageResponse.of(
                     infoPage
                 )
+            )
+        );
+  }
+
+  @PreAuthorize("hasRole('MASTER')")
+  @GetMapping("/unassign/{referenceId}")
+  public ResponseEntity<ApiResponse<Void>> unAssignManagers(
+      @PathVariable UUID referenceId) {
+    return ResponseEntity
+        .status(
+            CommonSuccessCode.OK.getStatus()
+        )
+        .body(
+            ApiResponse.success(
+                CommonSuccessCode.OK,
+                "소속된 관리자들이 해제되었습니다.",
+                userCommandService.unAssignManagersFromAdmin(
+
+                    UnAssignManagersCommand.from(referenceId))
             )
         );
   }

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/dto/response/UserDetailResponse.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/dto/response/UserDetailResponse.java
@@ -28,8 +28,8 @@ public record UserDetailResponse(
         .phoneNumber(command.phoneNumber().getNumber())
         .approvalStatus(command.approvalStatus().name())
         .userStatus(command.userStatus().name())
-        .userRole(command.userRole().getRole().name())
-        .referenceId(command.userRole().getReferenceId())
+        .userRole(command.role())
+        .referenceId(command.referenceId())
         .slackId(command.slackId())
         .updatedAt(command.updatedAt())
         .build();


### PR DESCRIPTION
### 📎 관련 이슈
- close #190

### 📌 작업 내용
- 소속 허브나 업체 삭제 시 소속 관리자들 SUSPEND 상태로 만들기
- UserRole nullable 하게 만들기
- userStatusType에 Suspend 타입 추가
- JwtAuthFilter에서 Role null 가능하게 만들기

### ✨ 변경 사항
- 주요 변경 내용 정리

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)