### PR TITLE
[Feat] 유저 승인, 거절, 삭제 및 Feign Client 연동

### DIFF
--- a/user-service/src/main/java/com/winner/client/userservice/common/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/winner/client/userservice/common/exception/UserErrorCode.java
@@ -11,6 +11,7 @@ public enum UserErrorCode implements ErrorCode {
   INVALID_INPUT_VALUE("ERROR_200", HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다"),
   LOGIN_FAILED("ERROR_201", HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다."),
   USER_NOT_APPROVED("ERROR_202", HttpStatus.FORBIDDEN, "아직 승인되지 않은 사용자입니다."),
+  ALREADY_USER_APPROVED("ERROR_202", HttpStatus.FORBIDDEN, "이미 승인된 사용자입니다."),
   USER_DELETED("ERROR_203", HttpStatus.GONE, "삭제된 사용자입니다."),
 
   INVALID_USER_STATUS_CHANGE("ERROR_204", HttpStatus.BAD_REQUEST, "변경할 수 없는 유저 상태입니다."),

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/port/DeliverManagerPort.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/port/DeliverManagerPort.java
@@ -1,0 +1,10 @@
+package com.winner.client.userservice.user.application.port;
+
+import com.winner.client.userservice.user.domain.entity.User;
+
+public interface DeliverManagerPort {
+
+  void deleteDeliveryManager(User user);
+
+  void registrationDeliveryManager(User user);
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/service/UserCommandService.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/service/UserCommandService.java
@@ -12,4 +12,10 @@ public interface UserCommandService {
   UserDetailResult updateUser(UserPatchCommand command);
 
   Void unAssignManagersFromAdmin(UnAssignManagersCommand command);
+
+  Void deleteUser(UUID userId);
+
+  UserDetailResult approveUser(UUID userId);
+
+  Void rejectUser(UUID userId);
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/application/service/impl/UserCommandServiceImpl.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/application/service/impl/UserCommandServiceImpl.java
@@ -6,8 +6,10 @@ import com.winner.client.userservice.common.exception.UserErrorCode;
 import com.winner.client.userservice.user.application.dto.command.UnAssignManagersCommand;
 import com.winner.client.userservice.user.application.dto.command.UserPatchCommand;
 import com.winner.client.userservice.user.application.dto.result.UserDetailResult;
+import com.winner.client.userservice.user.application.port.DeliverManagerPort;
 import com.winner.client.userservice.user.application.service.UserCommandService;
 import com.winner.client.userservice.user.domain.entity.User;
+import com.winner.client.userservice.user.domain.enums.RoleType;
 import com.winner.client.userservice.user.domain.repository.TokenRepository;
 import com.winner.client.userservice.user.domain.repository.UserRepository;
 import com.winner.client.userservice.user.domain.vo.PhoneNumber;
@@ -27,6 +29,7 @@ public class UserCommandServiceImpl implements UserCommandService {
   private final TokenRepository tokenRepository;
   private final JwtTokenProvider jwtTokenProvider;
   private final UserRepository userRepository;
+  private final DeliverManagerPort deliverManagerPort;
 
   @Override
   public Void logout(UUID userId, String accessToken) {
@@ -53,6 +56,44 @@ public class UserCommandServiceImpl implements UserCommandService {
   public Void unAssignManagersFromAdmin(UnAssignManagersCommand command) {
     List<User> users = userRepository.findAllByReferenceId(command.referenceId());
     users.forEach(User::suspend);
+    return null;
+  }
+
+  @Override
+  public Void deleteUser(UUID userId) {
+    User user = userRepository.findByIdAndDeletedAtNull(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    if (user.getUserRole().getRole() == RoleType.DELIVERY_MANAGER) {
+      deliverManagerPort.deleteDeliveryManager(user);
+    }
+    user.delete();
+    return null;
+  }
+
+  @Override
+  public UserDetailResult approveUser(UUID userId) {
+    User user = userRepository.findByIdAndDeletedAtNull(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    if (user.isApprove()) {
+      throw new BusinessException(UserErrorCode.ALREADY_USER_APPROVED);
+    }
+    user.approve();
+    if (user.getUserRole().getRole() == RoleType.DELIVERY_MANAGER) {
+      deliverManagerPort.registrationDeliveryManager(user);
+    }
+    user.active();
+
+    return UserDetailResult.from(user);
+  }
+
+  @Override
+  public Void rejectUser(UUID userId) {
+    User user = userRepository.findByIdAndDeletedAtNull(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    if (user.isApprove()) {
+      throw new BusinessException(UserErrorCode.ALREADY_USER_APPROVED);
+    }
+    user.reject();
     return null;
   }
 }

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/client/DeliveryManagerClient.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/client/DeliveryManagerClient.java
@@ -1,0 +1,29 @@
+package com.winner.client.userservice.user.infrastructure.client;
+
+import com.winner.client.userservice.user.infrastructure.client.dto.DeliveryManageHubRegistrationRequest;
+import com.winner.client.userservice.user.infrastructure.client.dto.DeliveryManagerCompanyRegistrationRequest;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "delivery-service")
+public interface DeliveryManagerClient {
+
+  @PostMapping("/internal/v1/delivery-managers/company")
+  Void registrationDeliveryCompanyManager(
+      @RequestBody DeliveryManagerCompanyRegistrationRequest request);
+
+  @PostMapping("/internal/v1/delivery-managers/hub")
+  Void registrationDeliveryHubManager(
+      @RequestBody DeliveryManageHubRegistrationRequest request);
+
+  @DeleteMapping("/internal/v1/delivery-managers/company/{userId}")
+  Void deleteDeliveryCompanyManger(@PathVariable UUID userId);
+
+  @DeleteMapping("/internal/v1/delivery-managers/hub/{userId}")
+  Void deleteDeliveryHubManger(@PathVariable UUID userId);
+
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/client/DeliveryManagerClientAdapter.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/client/DeliveryManagerClientAdapter.java
@@ -1,0 +1,46 @@
+package com.winner.client.userservice.user.infrastructure.client;
+
+import com.winner.client.global.exception.BusinessException;
+import com.winner.client.userservice.common.exception.UserErrorCode;
+import com.winner.client.userservice.user.application.port.DeliverManagerPort;
+import com.winner.client.userservice.user.domain.entity.User;
+import com.winner.client.userservice.user.infrastructure.client.dto.DeliveryManageHubRegistrationRequest;
+import com.winner.client.userservice.user.infrastructure.client.dto.DeliveryManagerCompanyRegistrationRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryManagerClientAdapter implements DeliverManagerPort {
+
+  private final DeliveryManagerClient deliveryManagerClient;
+
+  @Override
+  public void deleteDeliveryManager(User user) {
+    try {
+      if (user.getReferenceId() == null) {
+        deliveryManagerClient.deleteDeliveryHubManger(user.getId());
+      } else {
+        deliveryManagerClient.deleteDeliveryCompanyManger(user.getId());
+      }
+    } catch (Exception e) {
+      throw new BusinessException(UserErrorCode.ACTIVE_USER_CANNOT_WITHDRAW);
+    }
+  }
+
+  @Override
+  public void registrationDeliveryManager(User user) {
+    try {
+      if (user.getReferenceId() == null) {
+        deliveryManagerClient.registrationDeliveryHubManager(
+            DeliveryManageHubRegistrationRequest.from(user));
+      } else {
+        deliveryManagerClient.registrationDeliveryCompanyManager(
+            DeliveryManagerCompanyRegistrationRequest.from(user));
+      }
+    } catch (Exception e) {
+      throw new BusinessException(UserErrorCode.ACTIVE_USER_CANNOT_WITHDRAW);
+    }
+  }
+
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/client/DeliveryManagerClientAdapter.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/client/DeliveryManagerClientAdapter.java
@@ -1,6 +1,7 @@
 package com.winner.client.userservice.user.infrastructure.client;
 
 import com.winner.client.global.exception.BusinessException;
+import com.winner.client.global.exception.CommonErrorCode;
 import com.winner.client.userservice.common.exception.UserErrorCode;
 import com.winner.client.userservice.user.application.port.DeliverManagerPort;
 import com.winner.client.userservice.user.domain.entity.User;
@@ -39,7 +40,7 @@ public class DeliveryManagerClientAdapter implements DeliverManagerPort {
             DeliveryManagerCompanyRegistrationRequest.from(user));
       }
     } catch (Exception e) {
-      throw new BusinessException(UserErrorCode.ACTIVE_USER_CANNOT_WITHDRAW);
+      throw new BusinessException(CommonErrorCode.INTERNAL_SERVER_ERROR);
     }
   }
 

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/client/dto/DeliveryManageHubRegistrationRequest.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/client/dto/DeliveryManageHubRegistrationRequest.java
@@ -1,0 +1,19 @@
+package com.winner.client.userservice.user.infrastructure.client.dto;
+
+import com.winner.client.userservice.user.domain.entity.User;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record DeliveryManageHubRegistrationRequest(
+    UUID userId,
+    String name
+) {
+
+  public static DeliveryManageHubRegistrationRequest from(User user) {
+    return DeliveryManageHubRegistrationRequest.builder()
+        .userId(user.getId())
+        .name(user.getName())
+        .build();
+  }
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/client/dto/DeliveryManagerCompanyRegistrationRequest.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/infrastructure/client/dto/DeliveryManagerCompanyRegistrationRequest.java
@@ -1,0 +1,21 @@
+package com.winner.client.userservice.user.infrastructure.client.dto;
+
+import com.winner.client.userservice.user.domain.entity.User;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record DeliveryManagerCompanyRegistrationRequest(
+    UUID userId,
+    UUID hubId,
+    String name
+) {
+
+  public static DeliveryManagerCompanyRegistrationRequest from(User user) {
+    return DeliveryManagerCompanyRegistrationRequest.builder()
+        .userId(user.getId())
+        .hubId(user.getReferenceId())
+        .name(user.getName())
+        .build();
+  }
+}

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/controller/AdminController.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/controller/AdminController.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -87,6 +88,57 @@ public class AdminController {
             ApiResponse.success(CommonSuccessCode.OK,
                 "유저 목록을 조회하였습니다.",
                 PageResponse.of(infoPage)
+            )
+        );
+
+  }
+
+  @PatchMapping("/{userId}/approvals")
+  public ResponseEntity<ApiResponse<UserDetailResponse>> approveUserByAdmin
+      (@PathVariable UUID userId) {
+    return ResponseEntity
+        .status(
+            CommonSuccessCode.OK.getStatus()
+        )
+        .body(
+            ApiResponse.success(
+                CommonSuccessCode.OK,
+                "해당 사용자가 승인되었습니다.",
+                UserDetailResponse.from(
+                    userCommandService.approveUser(userId)
+                )
+            )
+        );
+  }
+
+  @PatchMapping("/{userId}/rejections")
+  public ResponseEntity<ApiResponse<Void>> rejectUserByAdmin
+      (@PathVariable UUID userId) {
+    return ResponseEntity
+        .status(
+            CommonSuccessCode.OK.getStatus()
+        )
+        .body(
+            ApiResponse.success(
+                CommonSuccessCode.OK,
+                "해당 사용자가 거절되었습니다.",
+                userCommandService.rejectUser(userId)
+            )
+        );
+  }
+
+
+  @DeleteMapping("/{userId}")
+  public ResponseEntity<ApiResponse<Void>> deleteUserByAdmin(@PathVariable UUID userId) {
+    return ResponseEntity
+        .status(
+            CommonSuccessCode.OK.getStatus()
+        )
+        .body(
+            ApiResponse.success(
+                CommonSuccessCode.OK,
+                "해당 사용자가 회원탈퇴 되었습니다.",
+                userCommandService.deleteUser(userId)
             )
         );
   }

--- a/user-service/src/main/java/com/winner/client/userservice/user/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/winner/client/userservice/user/presentation/controller/UserController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -67,7 +68,7 @@ public class UserController {
   }
 
   @PatchMapping("/me")
-  public ResponseEntity<ApiResponse<UserDetailResponse>> getUserDetail
+  public ResponseEntity<ApiResponse<UserDetailResponse>> updateUser
       (@AuthenticationPrincipal CustomUserPrincipal userPrincipal,
           @Valid @RequestBody UserPatchRequest request) {
     return ResponseEntity
@@ -85,4 +86,21 @@ public class UserController {
             )
         );
   }
+
+  @DeleteMapping("/me")
+  public ResponseEntity<ApiResponse<Void>> deleteUser(
+      @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+    return ResponseEntity
+        .status(
+            CommonSuccessCode.OK.getStatus()
+        )
+        .body(
+            ApiResponse.success(
+                CommonSuccessCode.OK,
+                "정상적으로 회원탈퇴 되었습니다.",
+                userCommandService.deleteUser(userPrincipal.userId())
+            )
+        );
+  }
+
 }


### PR DESCRIPTION
### 📎 관련 이슈
- close #208

### 📌 작업 내용
- 승인, 삭제 : 롤 타입이 배달 매니저라면 배달 매니저에게 feign client 호출해서 200 OK 응답시 승인
- 거절 : 단순 거절

### ✨ 변경 사항
- 주요 변경 내용 정리

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)