### PR TITLE
[feat]: 인증된 객체 사용을 위한 @AuthenticationPrincipal 추가

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
@@ -14,7 +14,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagercompany/presentation/api/DeliveryManagerCompanyController.java
@@ -6,9 +6,11 @@ import com.winner.client.deliveryservice.deliverymanagercompany.application.Deli
 import com.winner.client.deliveryservice.deliverymanagercompany.application.DeliveryManagerCompanyWriteService;
 import com.winner.client.deliveryservice.deliverymanagercompany.presentation.dto.responses.DeliveryManagerCompanyInfo;
 import com.winner.client.global.response.ApiResponse;
+import com.winner.client.global.security.CustomUserPrincipal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,10 +44,10 @@ public class DeliveryManagerCompanyController {
 
 	@PatchMapping("/{deliveryId}/completion")
 	public ResponseEntity<ApiResponse<Void>> completionDelivery(
-		@RequestHeader("X-User-Id") UUID userId,
+		@AuthenticationPrincipal CustomUserPrincipal principal,
 		@PathVariable UUID deliveryId
 	) {
-		deliveryManagerCompanyWriteService.completion(userId, deliveryId);
+		deliveryManagerCompanyWriteService.completion(principal.userId(), deliveryId);
 		return ResponseEntity.status(OK.getStatus())
 			.body(ApiResponse.success(OK, null));
 	}

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/presentation/api/DeliveryManagerHubController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/deliverymanagerhub/presentation/api/DeliveryManagerHubController.java
@@ -6,13 +6,14 @@ import com.winner.client.deliveryservice.deliverymanagerhub.application.Delivery
 import com.winner.client.deliveryservice.deliverymanagerhub.application.DeliveryManagerHubWriteService;
 import com.winner.client.deliveryservice.deliverymanagerhub.presentation.dto.responses.DeliveryManagerHubInfo;
 import com.winner.client.global.response.ApiResponse;
+import com.winner.client.global.security.CustomUserPrincipal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,20 +34,20 @@ public class DeliveryManagerHubController {
 				DeliveryManagerHubInfo.from(deliveryManagerHubReadService.getDetail(userId))));
 	}
 
-	@PatchMapping("/{userId}")
+	@PatchMapping
 	public ResponseEntity<ApiResponse<DeliveryManagerHubInfo>> switchStatus(
-		@PathVariable UUID userId
+		@AuthenticationPrincipal CustomUserPrincipal principal
 	) {
 		return ResponseEntity.ok().body(ApiResponse.success(OK,
-			DeliveryManagerHubInfo.from(deliveryManagerHubWriteService.switchStatus(userId))));
+			DeliveryManagerHubInfo.from(deliveryManagerHubWriteService.switchStatus(principal.userId()))));
 	}
 
 	@PatchMapping("/{deliveryId}/completion")
 	public ResponseEntity<ApiResponse<Void>> completionDelivery(
-		@RequestHeader("X-User-Id") UUID userId,
+		@AuthenticationPrincipal CustomUserPrincipal customUserPrincipal,
 		@PathVariable UUID deliveryId
 	) {
-		deliveryManagerHubWriteService.completion(userId, deliveryId);
+		deliveryManagerHubWriteService.completion(customUserPrincipal.userId(), deliveryId);
 		return ResponseEntity.status(OK.getStatus())
 			.body(ApiResponse.success(OK, null));
 	}


### PR DESCRIPTION
### 📎 관련 이슈
- close #207 

### 📌 작업 내용
- 배달담당자 배송완료 기능을 위한 @AuthenticationPrincipal 추가

### ✨ 변경 사항
- X-User-Id 대신 인증된 객체를 사용하기 위해 @AuthenticationPrincipal 사용

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)