### PR TITLE
[feat] 배송 삭제 및 배송 경로 일괄 저장되도록 수정

### DIFF
--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/delivery/DeliveryErrorCode.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/common/exception/delivery/DeliveryErrorCode.java
@@ -29,6 +29,7 @@ public enum DeliveryErrorCode implements ErrorCode {
   FIELD_CANNOT_BE_EMPTY_ADDRESS("ERROR_518", HttpStatus.BAD_REQUEST, "주소 필드(도로명, 상세)는 비워둘 수 없습니다."),
   INVALID_SEQUENCE("ERROR_519", HttpStatus.BAD_REQUEST, "순번(sequence)은 0 이상이어야 합니다."),
   INVALID_ROLE("ERROR_520", HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 역할(Role)입니다."),
+  NOT_CANCELLED_DELIVERY("ERROR_521", HttpStatus.BAD_REQUEST, "배송/배송 경로가 모두 취소되지 않았습니다"),
   ;
 
   private final String code;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryCommandService.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/DeliveryCommandService.java
@@ -17,4 +17,5 @@ public interface DeliveryCommandService {
       UUID deliveryId, UUID userId, String userRole, UUID referenceId);
   DeliveryCommandResponse cancelDelivery(
       UUID deliveryId, String userRole);
+  void deleteDelivery(UUID deliveryId, UUID userId, String userRole);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryAssignmentServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryAssignmentServiceImpl.java
@@ -26,7 +26,7 @@ public class DeliveryAssignmentServiceImpl implements DeliveryAssignmentService 
   @Transactional
   public void assignHubDeliveryManager(Delivery delivery, List<DeliveryRoute> routes) {
     deliveryRepository.save(delivery);
-    routes.forEach(deliveryRouteRepository::save);
+    deliveryRouteRepository.saveAll(routes);
     publishHubAssignEvent(delivery.getId());
   }
 

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryCommandServiceImpl.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/application/service/impl/DeliveryCommandServiceImpl.java
@@ -12,9 +12,12 @@ import com.winner.client.deliveryservice.delivery.application.validator.Delivery
 import com.winner.client.deliveryservice.delivery.application.validator.UserRole;
 import com.winner.client.deliveryservice.delivery.domain.entity.Delivery;
 import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
+import com.winner.client.deliveryservice.delivery.domain.enums.DeliveryRouteStatus;
 import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRepository;
+import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
 import com.winner.client.deliveryservice.delivery.presentation.dto.response.DeliveryCommandResponse;
 import com.winner.client.global.exception.BusinessException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeliveryCommandServiceImpl implements DeliveryCommandService {
 
   private final DeliveryRepository deliveryRepository;
+  private final DeliveryRouteRepository deliveryRouteRepository;
   private final DeliveryAssignmentService deliveryAssignmentService;
   private final DeliveryAccessValidator validator;
   private final HubRouteReader hubRouteReader;
@@ -109,6 +113,22 @@ public class DeliveryCommandServiceImpl implements DeliveryCommandService {
     Delivery delivery = findByIdWithRoutes(deliveryId);
     delivery.cancel();
     return DeliveryCommandResponse.from(delivery);
+  }
+
+  @Override
+  public void deleteDelivery(UUID deliveryId, UUID userId, String userRole) {
+    validator.validateRole(userRole, UserRole.MASTER);
+    Delivery delivery = findByIdWithRoutes(deliveryId);
+
+    boolean allCancelled = delivery.getRoutes().stream()
+        .allMatch(route -> route.getStatus() == DeliveryRouteStatus.CANCELLED);
+
+    if (!delivery.isCancelled() || !allCancelled) {
+      throw new BusinessException(DeliveryErrorCode.NOT_CANCELLED_DELIVERY);
+    }
+
+    delivery.softDelete(userId);
+    deliveryRouteRepository.softDeleteAllByDeliveryId(deliveryId, userId, LocalDateTime.now());
   }
 
   private Delivery findById(UUID deliveryId) {

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/Delivery.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/entity/Delivery.java
@@ -128,6 +128,10 @@ public class Delivery extends BaseAuditEntity {
     return hubRoute.isSameHub();
   }
 
+  public boolean isCancelled() {
+    return this.status == DeliveryStatus.CANCELLED;
+  }
+
   public void updateDeliveryManagerInfo(UUID deliveryManagerId, String DeliveryManagerName) {
     this.deliveryManagerId = deliveryManagerId;
     this.DeliveryManagerName = DeliveryManagerName;

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRouteRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/domain/repository/DeliveryRouteRepository.java
@@ -1,6 +1,7 @@
 package com.winner.client.deliveryservice.delivery.domain.repository;
 
 import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -10,5 +11,7 @@ public interface DeliveryRouteRepository {
   Optional<DeliveryRoute> findById(UUID id);
   Optional<DeliveryRoute> findFirstWaitingRoute(UUID deliveryId);
   Optional<DeliveryRoute> findFirstInProgressRoute(UUID deliveryId);
+  void softDeleteAllByDeliveryId(UUID deliveryId, UUID userId, LocalDateTime now);
   void save(DeliveryRoute route);
+  void saveAll(List<DeliveryRoute> routes);
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/DeliveryRouteJpaRepository.java
@@ -2,6 +2,7 @@ package com.winner.client.deliveryservice.delivery.infrastructure.repository;
 
 import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
 import com.winner.client.deliveryservice.delivery.domain.repository.DeliveryRouteRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -34,7 +35,17 @@ public class DeliveryRouteJpaRepository implements DeliveryRouteRepository {
   }
 
   @Override
+  public void softDeleteAllByDeliveryId(UUID deliveryId, UUID userId, LocalDateTime now) {
+    routeJpaRepository.softDeleteAllByDeliveryId(deliveryId, userId, now);
+  }
+
+  @Override
   public void save(DeliveryRoute route) {
     routeJpaRepository.save(route);
+  }
+
+  @Override
+  public void saveAll(List<DeliveryRoute> routes) {
+    routeJpaRepository.saveAll(routes);
   }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRouteRepository.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/infrastructure/repository/SpringDataDeliveryRouteRepository.java
@@ -1,10 +1,12 @@
 package com.winner.client.deliveryservice.delivery.infrastructure.repository;
 
 import com.winner.client.deliveryservice.delivery.domain.entity.DeliveryRoute;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -29,5 +31,17 @@ public interface SpringDataDeliveryRouteRepository extends JpaRepository<Deliver
     LIMIT 1
     """)
   Optional<DeliveryRoute> findFirstInProgressRoute(@Param("deliveryId") UUID deliveryId);
+
+  @Modifying(clearAutomatically = true)
+  @Query("""
+    UPDATE DeliveryRoute r
+    SET r.deletedAt = :now, r.deletedBy = :userId 
+    WHERE r.delivery.id = :deliveryId AND r.deletedAt IS NULL
+  """)
+  void softDeleteAllByDeliveryId(
+      @Param("deliveryId") UUID deliveryId,
+      @Param("userId") UUID userId,
+      @Param("now") LocalDateTime now
+  );
 
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/DeliveryController.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -42,7 +43,6 @@ public class DeliveryController {
   @PreAuthorize("hasRole('MASTER')")
   @PostMapping
   public CreateDeliveryResponse createDelivery(
-      @AuthenticationPrincipal CustomUserPrincipal principal,
       @RequestBody CreateDeliveryRequest request) {
     CreateDeliveryCommand command = CreateDeliveryCommand.from(request);
     CreateDeliveryResult result = deliveryCommandService.createDelivery(command);
@@ -69,7 +69,7 @@ public class DeliveryController {
 
   @GetMapping("/{deliveryId}")
   public ResponseEntity<ApiResponse<GetDeliveryResponse>> getDeliveryDetail(
-      @AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable UUID deliveryId) {
+      @PathVariable UUID deliveryId) {
     GetDeliveryResponse response =
         GetDeliveryResponse.from(deliveryQueryService.getDeliveryDetail(deliveryId));
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
@@ -78,7 +78,7 @@ public class DeliveryController {
 
   @GetMapping("/{deliveryId}/routes")
   public ResponseEntity<ApiResponse<ListDeliveryRouteResponse>> getDeliveryRoutes(
-      @AuthenticationPrincipal CustomUserPrincipal principal, @PathVariable UUID deliveryId){
+      @PathVariable UUID deliveryId){
     ListDeliveryRouteResponse response =
         ListDeliveryRouteResponse.from(deliveryQueryService.getDeliveryRoutes(deliveryId));
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
@@ -140,5 +140,17 @@ public class DeliveryController {
         = deliveryCommandService.cancelDelivery(deliveryId, principal.role());
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
+  }
+
+  @PreAuthorize("hasRole('MASTER')")
+  @DeleteMapping("/{deliveryId}")
+  public ResponseEntity<ApiResponse<DeliveryCommandResponse>> deleteDelivery(
+      @PathVariable UUID deliveryId,
+      @AuthenticationPrincipal CustomUserPrincipal principal
+  ){
+    deliveryCommandService.deleteDelivery(deliveryId, principal.userId(), principal.role());
+
+    return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
+        .body(ApiResponse.success(CommonSuccessCode.OK, null));
   }
 }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/DeliveryRouteController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/DeliveryRouteController.java
@@ -4,18 +4,18 @@ import com.winner.client.deliveryservice.delivery.application.service.DeliveryQu
 import com.winner.client.deliveryservice.delivery.application.service.DeliveryRouteCommandService;
 import com.winner.client.deliveryservice.delivery.presentation.dto.request.UpdateDeliveryRequest;
 import com.winner.client.deliveryservice.delivery.presentation.dto.response.DeliveryRouteCommandResponse;
-import com.winner.client.deliveryservice.delivery.presentation.dto.response.GetDeliveryResponse;
 import com.winner.client.deliveryservice.delivery.presentation.dto.response.GetDeliveryRouteResponse;
 import com.winner.client.global.response.ApiResponse;
 import com.winner.client.global.response.CommonSuccessCode;
+import com.winner.client.global.security.CustomUserPrincipal;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController("/api/v1/delivery-routes")
@@ -36,10 +36,10 @@ public class DeliveryRouteController {
   public ResponseEntity<ApiResponse<DeliveryRouteCommandResponse>> updateActualDeliveryRouteInfo(
       @PathVariable UUID routeId,
       @RequestBody UpdateDeliveryRequest request,
-      @RequestHeader("X-User-Id") UUID userId
+      @AuthenticationPrincipal CustomUserPrincipal principal
   ){
     DeliveryRouteCommandResponse response =
-        deliveryRouteCommandService.updateActualDeliveryRouteInfo(routeId, request, userId);
+        deliveryRouteCommandService.updateActualDeliveryRouteInfo(routeId, request, principal.userId());
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
   }
@@ -47,12 +47,10 @@ public class DeliveryRouteController {
   @PatchMapping("{routeId}/in-progress")
   public ResponseEntity<ApiResponse<DeliveryRouteCommandResponse>> startProgress(
       @PathVariable UUID routeId,
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
-      @RequestHeader("X-Reference-Id") UUID referenceId
+      @AuthenticationPrincipal CustomUserPrincipal principal
   ){
     DeliveryRouteCommandResponse response =
-        deliveryRouteCommandService.startProgress(routeId, userId, userRole, referenceId);
+        deliveryRouteCommandService.startProgress(routeId, principal.userId(), principal.role(), principal.referenceId());
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
   }
@@ -60,12 +58,10 @@ public class DeliveryRouteController {
   @PatchMapping("{routeId}/completed")
   public ResponseEntity<ApiResponse<DeliveryRouteCommandResponse>> completeRoute(
       @PathVariable UUID routeId,
-      @RequestHeader("X-User-Id") UUID userId,
-      @RequestHeader("X-User-Role") String userRole,
-      @RequestHeader("X-Reference-Id") UUID referenceId
+      @AuthenticationPrincipal CustomUserPrincipal principal
   ){
     DeliveryRouteCommandResponse response =
-        deliveryRouteCommandService.completeRoute(routeId, userId, userRole, referenceId);
+        deliveryRouteCommandService.completeRoute(routeId, principal.userId(), principal.role(), principal.referenceId());
     return ResponseEntity.status(CommonSuccessCode.OK.getStatus())
         .body(ApiResponse.success(CommonSuccessCode.OK, response));
   }

--- a/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/InternalDeliveryController.java
+++ b/delivery-service/src/main/java/com/winner/client/deliveryservice/delivery/presentation/controller/InternalDeliveryController.java
@@ -18,6 +18,7 @@ public class InternalDeliveryController {
 
   private final DeliveryCommandService deliveryCommandService;
 
+  @PostMapping
   public CreateDeliveryResponse createDelivery(@RequestBody CreateDeliveryRequest request) {
     CreateDeliveryCommand command = CreateDeliveryCommand.from(request);
     CreateDeliveryResult result = deliveryCommandService.createDelivery(command);

--- a/delivery-service/src/main/resources/application.yaml
+++ b/delivery-service/src/main/resources/application.yaml
@@ -19,6 +19,10 @@ spring:
         default_schema: delivery_db
         format_sql: true
         jdbc.time_zone: Asia/Seoul
+        jdbc:
+          batch_size: 30
+          order_inserts: true
+          order_updates: true
   sql:
     init:
       mode: never


### PR DESCRIPTION
### 📎 관련 이슈
- close #212 

### 📌 작업 내용
- 배송 경로 API에 인증 기능 추가
- 배송 삭제 API 추가
- 배송 경로 생성 시, saveAll을 사용하여 일괄 저장되도록 수정  

### ✨ 변경 사항
- saveAll 동작을 위한 `application.yml` 배치로 동작

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)